### PR TITLE
bluez5: Fixed for undefined 'bswap_128'

### DIFF
--- a/bluez5/attrib/att.c
+++ b/bluez5/attrib/att.c
@@ -32,7 +32,7 @@
 
 #include <glib.h>
 
-#include <bluetooth/bluetooth.h>
+#include "lib/bluetooth.h"
 #include "uuid.h"
 
 #include "src/shared/util.h"

--- a/bluez5/attrib/gatt.c
+++ b/bluez5/attrib/gatt.c
@@ -31,6 +31,7 @@
 
 #include <glib.h>
 
+#include "lib/bluetooth.h"
 #include "lib/sdp.h"
 #include "lib/sdp_lib.h"
 #include "uuid.h"


### PR DESCRIPTION
'bswap_128' has only be introduced in Bluez 5.29.
We use 'lib/bluetooth.h' instead of '/usr/include/bluetooth/bluetooth.h'