### PR TITLE
gattlib: added extern "C" {} around header

### DIFF
--- a/include/gattlib.h
+++ b/include/gattlib.h
@@ -24,6 +24,10 @@
 #ifndef __GATTLIB_H__
 #define __GATTLIB_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <glib.h>
 #include <stdint.h>
 
@@ -124,5 +128,9 @@ void gattlib_register_indication(gatt_connection_t* connection, gattlib_event_ha
 int gattlib_uuid_to_string(const uuid_t *uuid, char *str, size_t n);
 int gattlib_string_to_uuid(const char *str, size_t n, uuid_t *uuid);
 int gattlib_uuid_cmp(const uuid_t *uuid1, const uuid_t *uuid2);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
Hi, thanks for the library. I have noticed that the include/gattlib.h does not explicitly declare that it is in C language. To make it easier to include it in a C++ project, I propose adding the `extern "C"` statement around the header.
From what I have seen, at least the BlueZ header files already have it, so this should be the only place where the change is neccessary.