### PR TITLE
iteration / thread race condition fixes

### DIFF
--- a/bluez/gattlib_discover.c
+++ b/bluez/gattlib_discover.c
@@ -86,7 +86,7 @@ int gattlib_discover_primary(gatt_connection_t* connection, gattlib_primary_serv
 
 	// Wait for completion
 	while(user_data.discovered == FALSE) {
-		g_main_context_iteration(g_gattlib_thread.loop_context, FALSE);
+		gattlib_iteration();
 	}
 
 	*services       = user_data.services;
@@ -150,8 +150,9 @@ int gattlib_discover_char_range(gatt_connection_t* connection, int start, int en
 
 	// Wait for completion
 	while(user_data.discovered == FALSE) {
-		g_main_context_iteration(g_gattlib_thread.loop_context, FALSE);
+		gattlib_iteration();
 	}
+
 
 	*characteristics       = user_data.characteristics;
 	*characteristics_count = user_data.characteristics_count;
@@ -264,7 +265,7 @@ int gattlib_discover_desc_range(gatt_connection_t* connection, int start, int en
 
 	// Wait for completion
 	while(descriptor_data.discovered == FALSE) {
-		g_main_context_iteration(g_gattlib_thread.loop_context, FALSE);
+		gattlib_iteration();
 	}
 
 	*descriptors      = descriptor_data.descriptors;

--- a/bluez/gattlib_internal.h
+++ b/bluez/gattlib_internal.h
@@ -24,6 +24,12 @@
 #ifndef __GATTLIB_INTERNAL_H__
 #define __GATTLIB_INTERNAL_H__
 
+
+// uncomment the the following line to have an glib main event (g_main_loop_run)
+// loop created in its own thread for gattlib,  otherwise operations will
+// do gattlib_iterate when required.
+//#define USE_THREAD
+
 #include <glib.h>
 
 #define BLUEZ_VERSIONS(major, minor)	(((major) << 8) | (minor))
@@ -62,6 +68,7 @@ extern struct gattlib_thread_t g_gattlib_thread;
 GSource* gattlib_watch_connection_full(GIOChannel* io, GIOCondition condition,
 								 GIOFunc func, gpointer user_data, GDestroyNotify notify);
 GSource* gattlib_timeout_add_seconds(guint interval, GSourceFunc function, gpointer data);
+void gattlib_iteration(void);
 
 void uuid_to_bt_uuid(uuid_t* uuid, bt_uuid_t* bt_uuid);
 void bt_uuid_to_uuid(bt_uuid_t* bt_uuid, uuid_t* uuid);

--- a/bluez/gattlib_read_write.c
+++ b/bluez/gattlib_read_write.c
@@ -22,6 +22,8 @@
  */
 
 #include <stdlib.h>
+#include <semaphore.h>
+#include <errno.h>
 
 #include "gattlib_internal.h"
 
@@ -120,7 +122,7 @@ int gattlib_read_char_by_uuid(gatt_connection_t* connection, uuid_t* uuid,
 
 	// Wait for completion of the event
 	while(gattlib_result->completed == FALSE) {
-		g_main_context_iteration(g_gattlib_thread.loop_context, FALSE);
+		gattlib_iteration();
 	}
 
 	*buffer_len = gattlib_result->buffer_len;
@@ -178,7 +180,7 @@ int gattlib_write_char_by_handle(gatt_connection_t* connection, uint16_t handle,
 
 	// Wait for completion of the event
 	while(write_completed == FALSE) {
-		g_main_context_iteration(g_gattlib_thread.loop_context, FALSE);
+		gattlib_iteration();
 	}
 
 	return 0;


### PR DESCRIPTION
This is a fix for issue 31 where there is an occasional race condition because the glib GMainContext g_gattlib_thread->loop_context is run in two threads (explicitly not allowed in glib documentation).

I have provided 2 different fixes controlled by defining USE_THREAD in gattlib_internal.h.  The default operation does gattlib_iteration's as required.  When USE_THREAD is defined a main loop is run in a separate thread (this is the way it is done in the existing code) for processing glib events.  gattlib_iteration is still called but g_main_context_iteration is only called if gattlib_iteration was called from the same thread as the g_main_loop.

I do not like the USE_THREAD mode because:
1) <s>I do not think it is necessary</s>
2) The way it is implemented it is not very cpu friendly because it will be continuously looping on the event complete variables.  
3) I have tried using a mutex or semaphore for watching the thread complete variables instead, but they seem to create the same race conditions we started with.  This makes me think there is something in the Gatt code that is not thread safe.  I have not been able to track it down.

