### PR TITLE
Gattlib write char by uuid

### DIFF
--- a/bluez/bluez5/attrib/gattrib.c
+++ b/bluez/bluez5/attrib/gattrib.c
@@ -324,8 +324,10 @@ guint g_attrib_send(GAttrib *attrib, guint id, const guint8 *pdu, guint16 len,
 		cb->destroy_func = notify;
 		cb->parent = attrib;
 		queue_push_head(attrib->callbacks, cb);
-		response_cb = attrib_callback_result;
-		destroy_cb = attrib_callbacks_remove;
+		if ( func )
+			response_cb = attrib_callback_result;
+		if ( notify )
+			destroy_cb = attrib_callbacks_remove;
 
 	}
 

--- a/bluez/gattlib_connect.c
+++ b/bluez/gattlib_connect.c
@@ -384,7 +384,7 @@ gatt_connection_t *gattlib_connect(const char *src, const char *dst,
  * @param timeout_sec	connection timeout in seconds
  */
 gatt_connection_t *gattlib_connect_timeout(const char *src, const char *dst,
-				int8_t dest_type, gattlib_bt_sec_level_t sec_level,
+				uint8_t dest_type, gattlib_bt_sec_level_t sec_level,
 				int psm, int mtu, int timeout_sec)
 {
 	BtIOSecLevel bt_io_sec_level = get_bt_io_sec_level(sec_level);

--- a/bluez/gattlib_discover.c
+++ b/bluez/gattlib_discover.c
@@ -86,7 +86,7 @@ int gattlib_discover_primary(gatt_connection_t* connection, gattlib_primary_serv
 
 	// Wait for completion
 	while(user_data.discovered == FALSE) {
-		g_main_context_iteration(g_gattlib_thread.loop_context, FALSE);
+		gattlib_iteration();
 	}
 
 	*services       = user_data.services;
@@ -150,8 +150,9 @@ int gattlib_discover_char_range(gatt_connection_t* connection, int start, int en
 
 	// Wait for completion
 	while(user_data.discovered == FALSE) {
-		g_main_context_iteration(g_gattlib_thread.loop_context, FALSE);
+		gattlib_iteration();
 	}
+
 
 	*characteristics       = user_data.characteristics;
 	*characteristics_count = user_data.characteristics_count;
@@ -264,7 +265,7 @@ int gattlib_discover_desc_range(gatt_connection_t* connection, int start, int en
 
 	// Wait for completion
 	while(descriptor_data.discovered == FALSE) {
-		g_main_context_iteration(g_gattlib_thread.loop_context, FALSE);
+		gattlib_iteration();
 	}
 
 	*descriptors      = descriptor_data.descriptors;

--- a/bluez/gattlib_internal.h
+++ b/bluez/gattlib_internal.h
@@ -24,6 +24,12 @@
 #ifndef __GATTLIB_INTERNAL_H__
 #define __GATTLIB_INTERNAL_H__
 
+
+// uncomment the the following line to have an glib main event (g_main_loop_run)
+// loop created in its own thread for gattlib,  otherwise operations will
+// do gattlib_iterate when required.
+//#define USE_THREAD
+
 #include <glib.h>
 
 #define BLUEZ_VERSIONS(major, minor)	(((major) << 8) | (minor))
@@ -62,6 +68,7 @@ extern struct gattlib_thread_t g_gattlib_thread;
 GSource* gattlib_watch_connection_full(GIOChannel* io, GIOCondition condition,
 								 GIOFunc func, gpointer user_data, GDestroyNotify notify);
 GSource* gattlib_timeout_add_seconds(guint interval, GSourceFunc function, gpointer data);
+void gattlib_iteration(void);
 
 void uuid_to_bt_uuid(uuid_t* uuid, bt_uuid_t* bt_uuid);
 void bt_uuid_to_uuid(bt_uuid_t* bt_uuid, uuid_t* uuid);

--- a/bluez/gattlib_internal.h
+++ b/bluez/gattlib_internal.h
@@ -44,6 +44,8 @@
   #include "src/shared/util.h"
 #endif
 
+#define DEFAULT_TIMEOUT_SEC  5  // default timeout for operations
+
 struct gattlib_thread_t {
 	int           ref;
 	pthread_t     thread;

--- a/bluez/gattlib_read_write.c
+++ b/bluez/gattlib_read_write.c
@@ -22,6 +22,8 @@
  */
 
 #include <stdlib.h>
+#include <semaphore.h>
+#include <errno.h>
 
 #include "gattlib_internal.h"
 
@@ -120,7 +122,7 @@ int gattlib_read_char_by_uuid(gatt_connection_t* connection, uuid_t* uuid,
 
 	// Wait for completion of the event
 	while(gattlib_result->completed == FALSE) {
-		g_main_context_iteration(g_gattlib_thread.loop_context, FALSE);
+		gattlib_iteration();
 	}
 
 	*buffer_len = gattlib_result->buffer_len;
@@ -178,7 +180,7 @@ int gattlib_write_char_by_handle(gatt_connection_t* connection, uint16_t handle,
 
 	// Wait for completion of the event
 	while(write_completed == FALSE) {
-		g_main_context_iteration(g_gattlib_thread.loop_context, FALSE);
+		gattlib_iteration();
 	}
 
 	return 0;

--- a/bluez/gattlib_read_write.c
+++ b/bluez/gattlib_read_write.c
@@ -222,7 +222,7 @@ int gattlib_write_char_by_uuid(gatt_connection_t* connection, uuid_t* uuid, cons
 		return ret;
 	}
 
-	return gattlib_write_char_by_handle(connection, handle, buffer, sizeof(buffer));
+	return gattlib_write_char_by_handle(connection, handle, buffer, buffer_len);
 }
 
 int gattlib_notification_start(gatt_connection_t* connection, const uuid_t* uuid) {

--- a/dbus/gattlib.c
+++ b/dbus/gattlib.c
@@ -218,7 +218,7 @@ gatt_connection_t *gattlib_connect(const char *src, const char *dst,
  * @param psm       Specify the PSM for GATT/ATT over BR/EDR
  * @param mtu       Specify the MTU size
  */
-gatt_connection_t *gattlib_connect(const char *src, const char *dst,
+gatt_connection_t *gattlib_connect_timeout(const char *src, const char *dst,
 				uint8_t dest_type, gattlib_bt_sec_level_t sec_level, int psm, int mtu, int timeout_sec)
 {
 	GError *error = NULL;

--- a/dbus/gattlib.c
+++ b/dbus/gattlib.c
@@ -207,6 +207,20 @@ gboolean on_handle_device_property_change(
 gatt_connection_t *gattlib_connect(const char *src, const char *dst,
 				uint8_t dest_type, gattlib_bt_sec_level_t sec_level, int psm, int mtu)
 {
+	return gattlib_connect_timeout(src, dst, dest_type, sec_level, psm, mtu, CONNECT_TIMEOUT);
+}
+
+/**
+ * @param src		Local Adaptater interface
+ * @param dst		Remote Bluetooth address
+ * @param dst_type	Set LE address type (either BDADDR_LE_PUBLIC or BDADDR_LE_RANDOM)
+ * @param sec_level	Set security level (either BT_IO_SEC_LOW, BT_IO_SEC_MEDIUM, BT_IO_SEC_HIGH)
+ * @param psm       Specify the PSM for GATT/ATT over BR/EDR
+ * @param mtu       Specify the MTU size
+ */
+gatt_connection_t *gattlib_connect(const char *src, const char *dst,
+				uint8_t dest_type, gattlib_bt_sec_level_t sec_level, int psm, int mtu, int timeout_sec)
+{
 	GError *error = NULL;
 	const char* adapter_name;
 	char device_address_str[20];
@@ -273,7 +287,7 @@ gatt_connection_t *gattlib_connect(const char *src, const char *dst,
 		G_CALLBACK (on_handle_device_property_change),
 		loop);
 
-	g_timeout_add_seconds (CONNECT_TIMEOUT, stop_scan_func, loop);
+	g_timeout_add_seconds (timeout_sec, stop_scan_func, loop);
 	g_main_loop_run(loop);
 	g_main_loop_unref(loop);
 
@@ -291,6 +305,13 @@ FREE_CONNECTION:
 gatt_connection_t *gattlib_connect_async(const char *src, const char *dst,
 				uint8_t dest_type, gattlib_bt_sec_level_t sec_level, int psm, int mtu,
 				gatt_connect_cb_t connect_cb)
+{
+	return NULL;
+}
+
+gatt_connection_t *gattlib_connect_async_timeout(const char *src, const char *dst,
+				uint8_t dest_type, gattlib_bt_sec_level_t sec_level, int psm, int mtu,
+				gatt_connect_cb_t connect_cb, int timeout_sec)
 {
 	return NULL;
 }

--- a/include/gattlib.h
+++ b/include/gattlib.h
@@ -110,7 +110,7 @@ gatt_connection_t *gattlib_connect_async(const char *src, const char *dst,
 				gatt_connect_cb_t connect_cb);
 
 gatt_connection_t *gattlib_connect_timeout(const char *src, const char *dst,
-				int8_t dest_type, gattlib_bt_sec_level_t sec_level,
+				uint8_t dest_type, gattlib_bt_sec_level_t sec_level,
 				int psm, int mtu, int timeout_sec);
 gatt_connection_t *gattlib_connect_async_timeout(const char *src, const char *dst,
 				uint8_t dest_type, gattlib_bt_sec_level_t sec_level, int psm, int mtu,

--- a/include/gattlib.h
+++ b/include/gattlib.h
@@ -109,6 +109,13 @@ gatt_connection_t *gattlib_connect_async(const char *src, const char *dst,
 				uint8_t dest_type, gattlib_bt_sec_level_t sec_level, int psm, int mtu,
 				gatt_connect_cb_t connect_cb);
 
+gatt_connection_t *gattlib_connect_timeout(const char *src, const char *dst,
+				int8_t dest_type, gattlib_bt_sec_level_t sec_level,
+				int psm, int mtu, int timeout_sec);
+gatt_connection_t *gattlib_connect_async_timeout(const char *src, const char *dst,
+				uint8_t dest_type, gattlib_bt_sec_level_t sec_level, int psm, int mtu,
+				gatt_connect_cb_t connect_cb, int timeout_sec);
+
 int gattlib_disconnect(gatt_connection_t* connection);
 
 typedef struct {
@@ -141,6 +148,7 @@ int gattlib_read_char_by_uuid_async(gatt_connection_t* connection, uuid_t* uuid,
 
 int gattlib_write_char_by_uuid(gatt_connection_t* connection, uuid_t* uuid, const void* buffer, size_t buffer_len);
 int gattlib_write_char_by_handle(gatt_connection_t* connection, uint16_t handle, const void* buffer, size_t buffer_len);
+int gattlib_write_cmd_by_handle(gatt_connection_t* connection, uint16_t handle, const void* buffer, size_t buffer_len);
 
 /*
  * @param uuid     UUID of the characteristic that will trigger the notification


### PR DESCRIPTION
gattlib_write_char_by_uuid writes the incorrect buffer size.  This changes gattlib_write_char_by_uuid to use buffer_len rather than sizeof(buffer) when writing so it writes the correct buffer size.