### PR TITLE
Explicit linking examples

### DIFF
--- a/examples/ble_scan/CMakeLists.txt
+++ b/examples/ble_scan/CMakeLists.txt
@@ -24,8 +24,9 @@ cmake_minimum_required(VERSION 2.6)
 find_package(PkgConfig REQUIRED)
 
 pkg_search_module(GATTLIB REQUIRED gattlib)
+pkg_search_module(PCRE REQUIRED libpcre)
 
 set(ble_scan_SRCS ble_scan.c)
 
 add_executable(ble_scan ${ble_scan_SRCS})
-target_link_libraries(ble_scan ${GATTLIB_LDFLAGS} pthread)
+target_link_libraries(ble_scan ${GATTLIB_LDFLAGS} ${PCRE_LIBRARIES} pthread)

--- a/examples/ble_scan/CMakeLists.txt
+++ b/examples/ble_scan/CMakeLists.txt
@@ -29,4 +29,4 @@ pkg_search_module(PCRE REQUIRED libpcre)
 set(ble_scan_SRCS ble_scan.c)
 
 add_executable(ble_scan ${ble_scan_SRCS})
-target_link_libraries(ble_scan ${GATTLIB_LDFLAGS} ${PCRE_LIBRARIES} pthread)
+target_link_libraries(ble_scan ${GATTLIB_LIBRARIES} ${GATTLIB_LDFLAGS} ${PCRE_LIBRARIES} pthread)

--- a/examples/discover/CMakeLists.txt
+++ b/examples/discover/CMakeLists.txt
@@ -24,8 +24,9 @@ cmake_minimum_required(VERSION 2.6)
 find_package(PkgConfig REQUIRED)
 
 pkg_search_module(GATTLIB REQUIRED gattlib)
+pkg_search_module(PCRE REQUIRED libpcre)
 
 set(discover_SRCS discover.c)
 
 add_executable(discover ${discover_SRCS})
-target_link_libraries(discover ${GATTLIB_LDFLAGS})
+target_link_libraries(discover ${GATTLIB_LDFLAGS} ${PCRE_LIBRARIES} pthread)

--- a/examples/discover/CMakeLists.txt
+++ b/examples/discover/CMakeLists.txt
@@ -29,4 +29,4 @@ pkg_search_module(PCRE REQUIRED libpcre)
 set(discover_SRCS discover.c)
 
 add_executable(discover ${discover_SRCS})
-target_link_libraries(discover ${GATTLIB_LDFLAGS} ${PCRE_LIBRARIES} pthread)
+target_link_libraries(discover ${GATTLIB_LIBRARIES} ${GATTLIB_LDFLAGS} ${PCRE_LIBRARIES} pthread)

--- a/examples/gatttool/CMakeLists.txt
+++ b/examples/gatttool/CMakeLists.txt
@@ -52,4 +52,4 @@ endif()
 set(gatttool_SRCS gatttool.c interactive.c utils.c)
 
 add_executable(gatttool ${gatttool_SRCS})
-target_link_libraries(gatttool ${GATTLIB_LDFLAGS} ${GLIB_LDFLAGS} ${PCRE_LIBRARIES} readline tinfo pthread)
+target_link_libraries(gatttool ${GATTLIB_LIBRARIES} ${GATTLIB_LDFLAGS} ${GLIB_LDFLAGS} ${PCRE_LIBRARIES} readline tinfo pthread)

--- a/examples/gatttool/CMakeLists.txt
+++ b/examples/gatttool/CMakeLists.txt
@@ -25,6 +25,7 @@ find_package(PkgConfig REQUIRED)
 
 pkg_search_module(GATTLIB REQUIRED gattlib)
 pkg_search_module(GLIB REQUIRED glib-2.0)
+pkg_search_module(PCRE REQUIRED libpcre)
 
 include_directories(${GLIB_INCLUDE_DIRS})
 
@@ -51,4 +52,4 @@ endif()
 set(gatttool_SRCS gatttool.c interactive.c utils.c)
 
 add_executable(gatttool ${gatttool_SRCS})
-target_link_libraries(gatttool ${GATTLIB_LDFLAGS} ${GLIB_LDFLAGS} readline)
+target_link_libraries(gatttool ${GATTLIB_LDFLAGS} ${GLIB_LDFLAGS} ${PCRE_LIBRARIES} readline tinfo pthread)

--- a/examples/nordic_uart/CMakeLists.txt
+++ b/examples/nordic_uart/CMakeLists.txt
@@ -30,4 +30,4 @@ pkg_search_module(PCRE REQUIRED libpcre)
 set(nordic_uart_SRCS nordic_uart.c)
 
 add_executable(nordic_uart ${nordic_uart_SRCS})
-target_link_libraries(nordic_uart ${GATTLIB_LDFLAGS} ${PCRE_LIBRARIES} pthread)
+target_link_libraries(nordic_uart ${GATTLIB_LIBRARIES} ${GATTLIB_LDFLAGS} ${PCRE_LIBRARIES} pthread)

--- a/examples/nordic_uart/CMakeLists.txt
+++ b/examples/nordic_uart/CMakeLists.txt
@@ -25,8 +25,9 @@ cmake_minimum_required(VERSION 2.6)
 find_package(PkgConfig REQUIRED)
 
 pkg_search_module(GATTLIB REQUIRED gattlib)
+pkg_search_module(PCRE REQUIRED libpcre)
 
 set(nordic_uart_SRCS nordic_uart.c)
 
 add_executable(nordic_uart ${nordic_uart_SRCS})
-target_link_libraries(nordic_uart ${GATTLIB_LDFLAGS})
+target_link_libraries(nordic_uart ${GATTLIB_LDFLAGS} ${PCRE_LIBRARIES} pthread)

--- a/examples/notification/CMakeLists.txt
+++ b/examples/notification/CMakeLists.txt
@@ -26,9 +26,10 @@ find_package(PkgConfig REQUIRED)
 
 pkg_search_module(GATTLIB REQUIRED gattlib)
 pkg_search_module(GLIB REQUIRED glib-2.0)
+pkg_search_module(PCRE REQUIRED libpcre)
 
 include_directories(${GLIB_INCLUDE_DIRS})
 set(notification_SRCS notification.c)
 
 add_executable(notification ${notification_SRCS})
-target_link_libraries(notification ${GATTLIB_LDFLAGS} ${GLIB_LDFLAGS})
+target_link_libraries(notification ${GATTLIB_LDFLAGS} ${GLIB_LDFLAGS} ${PCRE_LIBRARIES} pthread)

--- a/examples/notification/CMakeLists.txt
+++ b/examples/notification/CMakeLists.txt
@@ -32,4 +32,4 @@ include_directories(${GLIB_INCLUDE_DIRS})
 set(notification_SRCS notification.c)
 
 add_executable(notification ${notification_SRCS})
-target_link_libraries(notification ${GATTLIB_LDFLAGS} ${GLIB_LDFLAGS} ${PCRE_LIBRARIES} pthread)
+target_link_libraries(notification ${GATTLIB_LIBRARIES} ${GATTLIB_LDFLAGS} ${GLIB_LDFLAGS} ${PCRE_LIBRARIES} pthread)

--- a/examples/read_write/CMakeLists.txt
+++ b/examples/read_write/CMakeLists.txt
@@ -25,8 +25,9 @@ cmake_minimum_required(VERSION 2.6)
 find_package(PkgConfig REQUIRED)
 
 pkg_search_module(GATTLIB REQUIRED gattlib)
+pkg_search_module(PCRE REQUIRED libpcre)
 
 set(read_write_SRCS read_write.c)
 
 add_executable(read_write ${read_write_SRCS})
-target_link_libraries(read_write ${GATTLIB_LDFLAGS})
+target_link_libraries(read_write ${GATTLIB_LDFLAGS} ${PCRE_LIBRARIES} pthread)

--- a/examples/read_write/CMakeLists.txt
+++ b/examples/read_write/CMakeLists.txt
@@ -30,4 +30,4 @@ pkg_search_module(PCRE REQUIRED libpcre)
 set(read_write_SRCS read_write.c)
 
 add_executable(read_write ${read_write_SRCS})
-target_link_libraries(read_write ${GATTLIB_LDFLAGS} ${PCRE_LIBRARIES} pthread)
+target_link_libraries(read_write ${GATTLIB_LIBRARIES} ${GATTLIB_LDFLAGS} ${PCRE_LIBRARIES} pthread)


### PR DESCRIPTION
Without explicitly linking the built libgattlib in the examples, a race condition can occur, when building the CMake Project on multiple cores.
By including it in the target_link_libraries, the dependency between the examples and the library are resolved.