### PR TITLE
User data pointer in gatt_connect_async callback

### DIFF
--- a/bluez/gattlib_discover.c
+++ b/bluez/gattlib_discover.c
@@ -141,18 +141,17 @@ int gattlib_discover_char_range(gatt_connection_t* connection, int start, int en
 	bzero(&user_data, sizeof(user_data));
 	user_data.discovered     = FALSE;
 
-	gattlib_context_t* conn_context = connection->context;
+    gattlib_context_t* conn_context = connection->context;
 	ret = gatt_discover_char(conn_context->attrib, start, end, NULL, characteristic_cb, &user_data);
 	if (ret == 0) {
 		fprintf(stderr, "Fail to discover characteristics.\n");
 		return 1;
 	}
 
-	// Wait for completion
-	while(user_data.discovered == FALSE) {
+    // Wait for completion
+	while(user_data.discovered == FALSE) {		
 		g_main_context_iteration(g_gattlib_thread.loop_context, FALSE);
-	}
-
+    }
 	*characteristics       = user_data.characteristics;
 	*characteristics_count = user_data.characteristics_count;
 

--- a/bluez/gattlib_read_write.c
+++ b/bluez/gattlib_read_write.c
@@ -179,8 +179,7 @@ int gattlib_write_char_by_handle(gatt_connection_t* connection, uint16_t handle,
 	// Wait for completion of the event
 	while(write_completed == FALSE) {
 		g_main_context_iteration(g_gattlib_thread.loop_context, FALSE);
-	}
-
+    }
 	return 0;
 }
 

--- a/dbus/gattlib.c
+++ b/dbus/gattlib.c
@@ -290,7 +290,7 @@ FREE_CONNECTION:
 
 gatt_connection_t *gattlib_connect_async(const char *src, const char *dst,
 				uint8_t dest_type, gattlib_bt_sec_level_t sec_level, int psm, int mtu,
-				gatt_connect_cb_t connect_cb)
+				gatt_connect_cb_t connect_cb, void* data)
 {
 	return NULL;
 }

--- a/examples/gatttool/gatttool.c
+++ b/examples/gatttool/gatttool.c
@@ -549,7 +549,7 @@ int main(int argc, char *argv[])
 	dest_type = get_dest_type_from_str(opt_dst_type);
 	sec_level = get_sec_level_from_str(opt_sec_level);
 	connection = gattlib_connect_async(opt_src, opt_dst, dest_type, sec_level,
-					opt_psm, opt_mtu, connect_cb);
+                    opt_psm, opt_mtu, connect_cb, NULL);
 	if (connection == NULL) {
 		got_error = TRUE;
 		goto done;

--- a/examples/gatttool/interactive.c
+++ b/examples/gatttool/interactive.c
@@ -110,7 +110,7 @@ static void set_state(enum state st)
 	rl_redisplay();
 }
 
-static void connect_cb(gatt_connection_t* connection)
+static void connect_cb(gatt_connection_t* connection, void* user_data)
 {
 	if (connection == NULL) {
 		set_state(STATE_DISCONNECTED);
@@ -304,7 +304,7 @@ static void cmd_connect(int argcp, char **argvp)
 	dst_type = get_dest_type_from_str(opt_dst_type);
 	sec_level = get_sec_level_from_str(opt_sec_level);
 	connection = gattlib_connect_async(opt_src, opt_dst, dst_type, sec_level,
-					opt_psm, opt_mtu, connect_cb);
+                    opt_psm, opt_mtu, connect_cb, NULL);
 	if (connection == NULL) {
 		set_state(STATE_DISCONNECTED);
 	} else {

--- a/include/gattlib.h
+++ b/include/gattlib.h
@@ -80,7 +80,7 @@ typedef struct _gatt_connection_t {
 } gatt_connection_t;
 
 typedef void (*gattlib_discovered_device_t)(const char* addr, const char* name);
-typedef void (*gatt_connect_cb_t)(gatt_connection_t* connection);
+typedef void (*gatt_connect_cb_t)(gatt_connection_t* connection, void* user_data);
 typedef void* (*gatt_read_cb_t)(const void* buffer, size_t buffer_len);
 
 
@@ -107,7 +107,7 @@ gatt_connection_t *gattlib_connect(const char *src, const char *dst,
 
 gatt_connection_t *gattlib_connect_async(const char *src, const char *dst,
 				uint8_t dest_type, gattlib_bt_sec_level_t sec_level, int psm, int mtu,
-				gatt_connect_cb_t connect_cb);
+                                gatt_connect_cb_t connect_cb, void* data);
 
 int gattlib_disconnect(gatt_connection_t* connection);
 


### PR DESCRIPTION
These was no user data in gatt connect callback. And it was difficult to understand in callback function which object's sent request for connection in case we have several object uses different BLE devices. In user data we could store pointer to structure or cpp class of sender