### PR TITLE
Async: Implementation of *_async versions for long-blocking calls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ set(ENV{PKG_CONFIG_PATH} "${PROJECT_BINARY_DIR}:$ENV{PKG_CONFIG_PATH}")
 
 # Examples
 add_subdirectory(examples/ble_scan)
+add_subdirectory(examples/ble_scan_async)
 add_subdirectory(examples/discover)
 add_subdirectory(examples/read_write)
 add_subdirectory(examples/notification)

--- a/dbus/CMakeLists.txt
+++ b/dbus/CMakeLists.txt
@@ -73,6 +73,7 @@ add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/org-bluez-gattdescriptor1.
 include_directories(. ${CMAKE_CURRENT_BINARY_DIR} ${GIO_UNIX_INCLUDE_DIRS} ${BLUEZ_INCLUDE_DIRS})
 
 set(gattlib_SRCS gattlib.c
+                 gattlib_async.c
                  bluez5/lib/uuid.c
                  ../gattlib_common.c
                  ${CMAKE_CURRENT_BINARY_DIR}/org-bluez-adaptater1.c

--- a/dbus/gattlib.c
+++ b/dbus/gattlib.c
@@ -22,6 +22,7 @@
  */
 
 #include <glib.h>
+
 #include <stdbool.h>
 #include <stdlib.h>
 
@@ -46,20 +47,39 @@ int gattlib_adapter_open(const char* adapter_name, void** adapter) {
 			object_path,
 			NULL, &error);
 	if (adapter_proxy == NULL) {
-		printf("Failed to get adapter %s\n", object_path);
+		ERROR_GATTLIB("Failed to get adapter %s\n", object_path);
 		return 1;
 	}
+
+
+	*adapter = adapter_proxy;
 
 	// Ensure the adapter is powered on
 	org_bluez_adapter1_set_powered(adapter_proxy, TRUE);
 
-	*adapter = adapter_proxy;
+
 	return 0;
 }
 
-static gboolean stop_scan_func(gpointer data) {
+/* gattlib_adapter_powered -- returns gboolean TRUE (1) if powered.
+ * This is useful because you can open the adapter and still not
+ * have access to functionaliy, if the user has "turned bluetooth off"
+ * manually.
+ */
+int gattlib_adapter_powered(void* adapter) {
+	OrgBluezAdapter1 *adapter_proxy = adapter;
+	return org_bluez_adapter1_get_powered(adapter_proxy);
+}
+
+static gboolean loop_timeout_func(gpointer data) {
+	DEBUG_GATTLIB("\nloop_timeout_func()!\n");
 	g_main_loop_quit(data);
 	return FALSE;
+}
+
+static gboolean stop_scan_func(gpointer data) {
+	DEBUG_GATTLIB("\nstop_scan_func()!\n");
+	return loop_timeout_func(data);
 }
 
 void on_dbus_object_added(GDBusObjectManager *device_manager,
@@ -91,9 +111,18 @@ void on_dbus_object_added(GDBusObjectManager *device_manager,
 	}
 }
 
-int gattlib_adapter_scan_enable(void* adapter, gattlib_discovered_device_t discovered_device_cb, int timeout) {
-	GDBusObjectManager *device_manager;
+
+/*
+ * gattlib_adapter_scan_enable_setup
+ * functionality brought out of scan_enable to allow
+ * re-use for async version
+ */
+int gattlib_adapter_scan_enable_setup(void* adapter, gattlib_discovered_device_t discovered_device_cb,
+	GDBusObjectManager **dev_manager) {
+	
+	GDBusObjectManager *device_manager ;
 	GError *error = NULL;
+	*dev_manager = NULL;
 
 	org_bluez_adapter1_call_start_discovery_sync((OrgBluezAdapter1*)adapter, NULL, &error);
 
@@ -149,6 +178,23 @@ int gattlib_adapter_scan_enable(void* adapter, gattlib_discovered_device_t disco
 	                    G_CALLBACK (on_dbus_object_added),
 	                    discovered_device_cb);
 
+	*dev_manager = device_manager;
+
+	return 0;
+
+}
+
+
+
+int gattlib_adapter_scan_enable(void* adapter, gattlib_discovered_device_t discovered_device_cb, int timeout) {
+
+	GDBusObjectManager *device_manager;
+	int setupReturn = gattlib_adapter_scan_enable_setup(adapter, discovered_device_cb, &device_manager);
+	if (setupReturn)
+	{
+		return setupReturn;
+	}
+
 	// Run Glib loop for 'timeout' seconds
 	GMainLoop *loop = g_main_loop_new(NULL, 0);
 	g_timeout_add_seconds (timeout, stop_scan_func, loop);
@@ -159,12 +205,18 @@ int gattlib_adapter_scan_enable(void* adapter, gattlib_discovered_device_t disco
 	return 0;
 }
 
+
+
 int gattlib_adapter_scan_disable(void* adapter) {
 	GError *error = NULL;
 
 	org_bluez_adapter1_call_stop_discovery_sync((OrgBluezAdapter1*)adapter, NULL, &error);
 	return 0;
 }
+
+
+
+
 
 int gattlib_adapter_close(void* adapter) {
 	g_object_unref(adapter);
@@ -219,6 +271,9 @@ gatt_connection_t *gattlib_connect(const char *src, const char *dst,
 		adapter_name = "hci0";
 	}
 
+
+	DEBUG_GATTLIB("gattlib attempting connect through adapter %s\n", adapter_name);
+
 	// Transform string from 'DA:94:40:95:E0:87' to 'dev_DA_94_40_95_E0_87'
 	strncpy(device_address_str, dst, sizeof(device_address_str));
 	for (i = 0; i < strlen(device_address_str); i++) {
@@ -232,11 +287,13 @@ gatt_connection_t *gattlib_connect(const char *src, const char *dst,
 
 	gattlib_context_t* conn_context = calloc(sizeof(gattlib_context_t), 1);
 	if (conn_context == NULL) {
+		DEBUG_GATTLIB("connect() couldn't calloc context!\n");
 		return NULL;
 	}
 
 	gatt_connection_t* connection = calloc(sizeof(gatt_connection_t), 1);
 	if (connection == NULL) {
+		DEBUG_GATTLIB("connect() couldn't calloc connection!\n");
 		return NULL;
 	} else {
 		connection->context = conn_context;
@@ -250,30 +307,39 @@ gatt_connection_t *gattlib_connect(const char *src, const char *dst,
 			NULL,
 			&error);
 	if (device == NULL) {
+		DEBUG_GATTLIB("connect() device not present!\n");
 		goto FREE_CONNECTION;
 	} else {
 		conn_context->device = device;
 		conn_context->device_object_path = strdup(object_path);
 	}
 
+
 	error = NULL;
 	org_bluez_device1_call_connect_sync(device, NULL, &error);
 	if (error) {
-		printf("Device connected error: %s\n", error->message);
+		ERROR_GATTLIB("Device connected error: %s\n", error->message);
 		goto FREE_DEVICE;
 	}
 
 	// Wait for the property 'UUIDs' to be changed. We assume 'org.bluez.GattService1
 	// and 'org.bluez.GattCharacteristic1' to be advertised at that moment.
-	GMainLoop *loop = g_main_loop_new(NULL, 0);
 
+
+
+
+
+
+	DEBUG_GATTLIB("gattlib_connect starting loop (timeout %i s.)\n", CONNECT_TIMEOUT);
+
+	GMainLoop *loop = g_main_loop_new(NULL, 0);
 	// Register a handle for notification
 	g_signal_connect(device,
 		"g-properties-changed",
 		G_CALLBACK (on_handle_device_property_change),
 		loop);
 
-	g_timeout_add_seconds (CONNECT_TIMEOUT, stop_scan_func, loop);
+	g_timeout_add_seconds (CONNECT_TIMEOUT, loop_timeout_func, loop);
 	g_main_loop_run(loop);
 	g_main_loop_unref(loop);
 
@@ -288,17 +354,14 @@ FREE_CONNECTION:
 	return NULL;
 }
 
-gatt_connection_t *gattlib_connect_async(const char *src, const char *dst,
-				uint8_t dest_type, gattlib_bt_sec_level_t sec_level, int psm, int mtu,
-				gatt_connect_cb_t connect_cb)
-{
-	return NULL;
-}
+
+
 
 int gattlib_disconnect(gatt_connection_t* connection) {
 	gattlib_context_t* conn_context = connection->context;
 	GError *error = NULL;
 
+	DEBUG_GATTLIB("gattlib_disconnect\n");
 	org_bluez_device1_call_disconnect_sync(conn_context->device, NULL, &error);
 
 	free(conn_context->device_object_path);
@@ -308,6 +371,7 @@ int gattlib_disconnect(gatt_connection_t* connection) {
 	free(connection);
 	return 0;
 }
+
 
 // Bluez was using org.bluez.Device1.GattServices until 5.37 to expose the list of available GATT Services
 #if BLUEZ_VERSION < BLUEZ_VERSIONS(5, 38)
@@ -346,7 +410,7 @@ int gattlib_discover_primary(gatt_connection_t* connection, gattlib_primary_serv
 				NULL,
 				&error);
 		if (service_proxy == NULL) {
-			printf("Failed to open service '%s'.\n", *service_str);
+			ERROR_GATTLIB("Failed to open service '%s'.\n", *service_str);
 			continue;
 		}
 
@@ -426,7 +490,7 @@ int gattlib_discover_primary(gatt_connection_t* connection, gattlib_primary_serv
 				NULL,
 				&error);
 		if (service_proxy == NULL) {
-			printf("Failed to open service '%s'.\n", object_path);
+			ERROR_GATTLIB("Failed to open service '%s'.\n", object_path);
 			continue;
 		}
 
@@ -488,7 +552,7 @@ int gattlib_discover_char(gatt_connection_t* connection, gattlib_characteristic_
 				NULL,
 				&error);
 		if (service_proxy == NULL) {
-			printf("Failed to open services '%s'.\n", *service_str);
+			ERROR_GATTLIB("Failed to open services '%s'.\n", *service_str);
 			continue;
 		}
 
@@ -519,7 +583,7 @@ int gattlib_discover_char(gatt_connection_t* connection, gattlib_characteristic_
 				NULL,
 				&error);
 		if (service_proxy == NULL) {
-			printf("Failed to open service '%s'.\n", *service_str);
+			ERROR_GATTLIB("Failed to open service '%s'.\n", *service_str);
 			continue;
 		}
 
@@ -537,29 +601,38 @@ int gattlib_discover_char(gatt_connection_t* connection, gattlib_characteristic_
 					NULL,
 					&error);
 			if (characteristic_proxy == NULL) {
-				printf("Failed to open characteristic '%s'.\n", *characteristic_str);
+				ERROR_GATTLIB("Failed to open characteristic '%s'.\n", *characteristic_str);
 				continue;
 			} else {
 				characteristic_list[count].handle       = 0;
 				characteristic_list[count].value_handle = 0;
 
+				DEBUG_GATTLIB("gattlib got char: ");
 				const gchar *const * flags = org_bluez_gatt_characteristic1_get_flags(characteristic_proxy);
 				for (; *flags != NULL; flags++) {
 					if (strcmp(*flags,"broadcast") == 0) {
+						DEBUG_GATTLIB("bcast ");
 						characteristic_list[count].properties |= GATTLIB_CHARACTERISTIC_BROADCAST;
 					} else if (strcmp(*flags,"read") == 0) {
+						DEBUG_GATTLIB("read ");
 						characteristic_list[count].properties |= GATTLIB_CHARACTERISTIC_READ;
 					} else if (strcmp(*flags,"write") == 0) {
+						DEBUG_GATTLIB("write ");
 						characteristic_list[count].properties |= GATTLIB_CHARACTERISTIC_WRITE;
 					} else if (strcmp(*flags,"write-without-response") == 0) {
+						DEBUG_GATTLIB("write[no resp] ");
 						characteristic_list[count].properties |= GATTLIB_CHARACTERISTIC_WRITE_WITHOUT_RESP;
 					} else if (strcmp(*flags,"notify") == 0) {
+						DEBUG_GATTLIB("notify ");
 						characteristic_list[count].properties |= GATTLIB_CHARACTERISTIC_NOTIFY;
 					} else if (strcmp(*flags,"indicate") == 0) {
+						DEBUG_GATTLIB("indicate ");
 						characteristic_list[count].properties |= GATTLIB_CHARACTERISTIC_INDICATE;
 					}
 				}
 
+
+				DEBUG_GATTLIB("\n");
 				gattlib_string_to_uuid(
 						org_bluez_gatt_characteristic1_get_uuid(characteristic_proxy),
 						MAX_LEN_UUID_STR + 1,
@@ -597,7 +670,7 @@ static void add_characteristics_from_service(GDBusObjectManager *device_manager,
 				NULL,
 				&error);
 		if (characteristic == NULL) {
-			printf("Failed to open characteristic '%s'.\n", object_path);
+			ERROR_GATTLIB("Failed to open characteristic '%s'.\n", object_path);
 			continue;
 		}
 
@@ -607,22 +680,33 @@ static void add_characteristics_from_service(GDBusObjectManager *device_manager,
 			characteristic_list[*count].handle       = 0;
 			characteristic_list[*count].value_handle = 0;
 
+
+			DEBUG_GATTLIB("gattlib got char: ");
+
 			const gchar *const * flags = org_bluez_gatt_characteristic1_get_flags(characteristic);
 			for (; *flags != NULL; flags++) {
 				if (strcmp(*flags,"broadcast") == 0) {
+					DEBUG_GATTLIB("bcast ");
 					characteristic_list[*count].properties |= GATTLIB_CHARACTERISTIC_BROADCAST;
 				} else if (strcmp(*flags,"read") == 0) {
+					DEBUG_GATTLIB("read ");
 					characteristic_list[*count].properties |= GATTLIB_CHARACTERISTIC_READ;
 				} else if (strcmp(*flags,"write") == 0) {
+					DEBUG_GATTLIB("write ");
 					characteristic_list[*count].properties |= GATTLIB_CHARACTERISTIC_WRITE;
 				} else if (strcmp(*flags,"write-without-response") == 0) {
+					DEBUG_GATTLIB("write[no resp] ");
 					characteristic_list[*count].properties |= GATTLIB_CHARACTERISTIC_WRITE_WITHOUT_RESP;
 				} else if (strcmp(*flags,"notify") == 0) {
+					DEBUG_GATTLIB("notify ");
 					characteristic_list[*count].properties |= GATTLIB_CHARACTERISTIC_NOTIFY;
 				} else if (strcmp(*flags,"indicate") == 0) {
+					DEBUG_GATTLIB("indicate ");
 					characteristic_list[*count].properties |= GATTLIB_CHARACTERISTIC_INDICATE;
 				}
 			}
+
+			DEBUG_GATTLIB("\n");
 
 			gattlib_string_to_uuid(
 					org_bluez_gatt_characteristic1_get_uuid(characteristic),
@@ -688,7 +772,7 @@ int gattlib_discover_char(gatt_connection_t* connection, gattlib_characteristic_
 				NULL,
 				&error);
 		if (service_proxy == NULL) {
-			printf("Failed to open service '%s'.\n", object_path);
+			ERROR_GATTLIB("Failed to open service '%s'.\n", object_path);
 			continue;
 		}
 
@@ -711,7 +795,8 @@ int gattlib_discover_char(gatt_connection_t* connection, gattlib_characteristic_
 }
 #endif
 
-static OrgBluezGattCharacteristic1 *get_characteristic_from_uuid(const uuid_t* uuid) {
+
+OrgBluezGattCharacteristic1 *get_characteristic_from_uuid(const uuid_t* uuid) {
 	OrgBluezGattCharacteristic1 *characteristic = NULL;
 	GError *error = NULL;
 
@@ -814,45 +899,11 @@ int gattlib_read_char_by_uuid(gatt_connection_t* connection, uuid_t* uuid, void*
 	return 0;
 }
 
-int gattlib_read_char_by_uuid_async(gatt_connection_t* connection, uuid_t* uuid, gatt_read_cb_t gatt_read_cb) {
-	OrgBluezGattCharacteristic1 *characteristic = get_characteristic_from_uuid(uuid);
-	if (characteristic == NULL) {
-		return -1;
-	}
-
-	GVariant *out_value;
-	GError *error = NULL;
-
-#if BLUEZ_VERSION < BLUEZ_VERSIONS(5, 40)
-	org_bluez_gatt_characteristic1_call_read_value_sync(
-		characteristic, &out_value, NULL, &error);
-#else
-	GVariantBuilder *options =  g_variant_builder_new(G_VARIANT_TYPE("a{sv}"));
-	org_bluez_gatt_characteristic1_call_read_value_sync(
-		characteristic, g_variant_builder_end(options), &out_value, NULL, &error);
-	g_variant_builder_unref(options);
-#endif
-	if (error != NULL) {
-		return -1;
-	}
-
-	gsize n_elements;
-	gconstpointer const_buffer = g_variant_get_fixed_array(out_value, &n_elements, sizeof(guchar));
-	if (const_buffer) {
-		gatt_read_cb(const_buffer, n_elements);
-	}
-
-	g_object_unref(characteristic);
-
-#if BLUEZ_VERSION >= BLUEZ_VERSIONS(5, 40)
-	//g_variant_unref(in_params); See: https://github.com/labapart/gattlib/issues/28#issuecomment-311486629
-#endif
-	return 0;
-}
-
 int gattlib_write_char_by_uuid(gatt_connection_t* connection, uuid_t* uuid, const void* buffer, size_t buffer_len) {
 	OrgBluezGattCharacteristic1 *characteristic = get_characteristic_from_uuid(uuid);
 	if (characteristic == NULL) {
+
+		DEBUG_GATTLIB("\nwrite() can't find this characteristic!\n");
 		return -1;
 	}
 
@@ -867,6 +918,7 @@ int gattlib_write_char_by_uuid(gatt_connection_t* connection, uuid_t* uuid, cons
 	g_variant_builder_unref(options);
 #endif
 	if (error != NULL) {
+		DEBUG_GATTLIB("\nwrite() error returned from bluez write\n");
 		return -1;
 	}
 
@@ -889,37 +941,51 @@ gboolean on_handle_characteristic_property_change(
 {
 	gatt_connection_t* connection = user_data;
 
-	if (connection->notification_handler) {
-		// Retrieve 'Value' from 'arg_changed_properties'
-		if (g_variant_n_children (arg_changed_properties) > 0) {
-			GVariantIter *iter;
-			const gchar *key;
-			GVariant *value;
+	DEBUG_GATTLIB("\nchar prop changed called ");
+	if (!connection->notification_handler) {
+		DEBUG_GATTLIB("but we have NO notification_handler\n");
+		return TRUE;
+	}
+	DEBUG_GATTLIB("and we have notification_handler ");
+	// Retrieve 'Value' from 'arg_changed_properties'
 
-			g_variant_get (arg_changed_properties, "a{sv}", &iter);
-			while (g_variant_iter_loop (iter, "{&sv}", &key, &value)) {
-				if (strcmp(key, "Value") == 0) {
-					uuid_t uuid;
-					size_t data_length;
-					const uint8_t* data = g_variant_get_fixed_array(value, &data_length, sizeof(guchar));
+	if (g_variant_n_children(arg_changed_properties) <= 0) {
 
-					gattlib_string_to_uuid(
-							org_bluez_gatt_characteristic1_get_uuid(object),
-							MAX_LEN_UUID_STR + 1,
-							&uuid);
+		DEBUG_GATTLIB(" but 0 changed properties...\n");
+	}
+	DEBUG_GATTLIB(" and some changed properties...\n");
+	GVariantIter *iter;
+	const gchar *key;
+	GVariant *value;
 
-					connection->notification_handler(&uuid, data, data_length, user_data);
-					break;
-				}
-			}
+	g_variant_get(arg_changed_properties, "a{sv}", &iter);
+	while (g_variant_iter_loop(iter, "{&sv}", &key, &value)) {
+		if (strcmp(key, "Value") == 0) {
+			uuid_t uuid;
+			size_t data_length;
+			const uint8_t* data = g_variant_get_fixed_array(value, &data_length,
+					sizeof(guchar));
+
+			DEBUG_GATTLIB("Got Value of len %li, passing to notif handler\n", data_length);
+			gattlib_string_to_uuid(
+					org_bluez_gatt_characteristic1_get_uuid(object),
+					MAX_LEN_UUID_STR + 1, &uuid);
+
+			connection->notification_handler(&uuid, data, data_length,
+					user_data);
+			break;
 		}
 	}
+
+
 	return TRUE;
 }
 
 int gattlib_notification_start(gatt_connection_t* connection, const uuid_t* uuid) {
+	DEBUG_GATTLIB("\ngattlib_notification_start()... ");
 	OrgBluezGattCharacteristic1 *characteristic = get_characteristic_from_uuid(uuid);
 	if (characteristic == NULL) {
+		DEBUG_GATTLIB("can't find this char\n");
 		return -1;
 	}
 
@@ -933,15 +999,20 @@ int gattlib_notification_start(gatt_connection_t* connection, const uuid_t* uuid
 	org_bluez_gatt_characteristic1_call_start_notify_sync(characteristic, NULL, &error);
 
 	if (error) {
+
+		DEBUG_GATTLIB("error returned by bluez start notify\n");
 		return 1;
 	} else {
+		DEBUG_GATTLIB("OK\n");
 		return 0;
 	}
 }
 
 int gattlib_notification_stop(gatt_connection_t* connection, const uuid_t* uuid) {
+	DEBUG_GATTLIB("\ngattlib_notification_stop()... ");
 	OrgBluezGattCharacteristic1 *characteristic = get_characteristic_from_uuid(uuid);
 	if (characteristic == NULL) {
+		DEBUG_GATTLIB("can't find this char\n");
 		return -1;
 	}
 
@@ -950,8 +1021,10 @@ int gattlib_notification_stop(gatt_connection_t* connection, const uuid_t* uuid)
 		characteristic, NULL, &error);
 
 	if (error) {
+		DEBUG_GATTLIB("error returned by bluez start notify\n");
 		return 1;
 	} else {
+		DEBUG_GATTLIB("OK\n");
 		return 0;
 	}
 }

--- a/dbus/gattlib_async.c
+++ b/dbus/gattlib_async.c
@@ -1,0 +1,730 @@
+/*
+ *
+ *  GattLib Async - GATT Library Asynchronous functions
+ *
+ *  Copyright (C) 2017 Pat Deegan, psychogenic.com
+ *
+ *   Async expansions to the GattLib library.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+
+
+/*
+ * *** Async Notes ***
+ *
+ *  Async versions of the worst-offenders (slowest/longest blocking)
+ *  are now available and implemented here.
+ *
+ *  These operations hey need some time allocated
+ *  in order to process events, trigger callbacks, etc.  The simplest
+ *  way to do this is to periodically give them a moment in your main
+ *  loop, eg
+ *
+ *  while (1) {
+ *  	// handle user events
+ *  	// do processing, etc.
+ *
+ *  	// process any async events
+ *  	gattlib_async_process();
+ *
+ *  }
+ *
+ *
+ *
+ *
+ */
+
+#include <glib.h>
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "gattlib_internal.h"
+
+/* decl -- implemented in gattlib.c, re-used here */
+int gattlib_adapter_scan_enable_setup(void* adapter, gattlib_discovered_device_t discovered_device_cb,
+	GDBusObjectManager **dev_manager);
+
+
+#define GATTLIB_ASYNC_LOOP_CREATECONTEXT		TRUE
+/*
+ * ************* Async Structures and Utility Functions *************
+ */
+typedef void (*async_cleanuptime_cb_t)(void);
+
+/* our state... single struct to hold anything our async
+ * stuff needs.
+ */
+typedef struct gattlib_async_statestruct {
+
+	/*
+	 * async functions will have a specific "main" loop
+	 * associated with them, so they can run tasks/handle
+	 * timeouts etc.
+	 */
+	GMainContext *current_context;
+	GMainLoop * current_loop;
+	GSource *	timeout_source;
+
+
+	/*
+	 * callbacks they may be assigned for specific _async()
+	 * calls.
+	 * done_callback is a generic "this method is done" call.
+	 *
+	 */
+	gattlib_async_completed_cb_t done_callback;
+	gattlib_async_error_cb_t error_callback;
+	gatt_connect_cb_t connection_done_cb;
+	gboolean am_scanning;
+
+	/*
+	 * internals
+	 */
+	async_cleanuptime_cb_t cleanup;
+	void * async_proc_data;
+
+} gattlib_async_state_t;
+
+static volatile gattlib_async_state_t gattlib_async_global_state = { 0 };
+
+/*
+ * gattlib_async_quit_currentloop() -- mark the current loop as done
+ */
+static void gattlib_async_quit_currentloop() {
+	DEBUG_GATTLIB("async_quit_currentloop()\n");
+	if (gattlib_async_global_state.current_loop) {
+		g_main_loop_quit(gattlib_async_global_state.current_loop);
+	} else {
+		DEBUG_GATTLIB("booo, no loop?\n");
+	}
+}
+
+
+
+/*
+ * gattlib_timeout_async_loop() -- general callback for async loop
+ * timeouts.
+ */
+static gboolean gattlib_timeout_async_loop(gpointer data) {
+	DEBUG_GATTLIB("\nasync timeout called\n");
+	if (data) {
+		// if (gattlib_async_global_state.current_loop) {
+		DEBUG_GATTLIB("sending timeout quit to loop\n");
+		// g_main_loop_quit(gattlib_async_global_state.current_loop);
+		g_main_loop_quit(data);
+	}
+
+	return FALSE;
+}
+
+/*
+ * gattlib_async_setup_currentloop(TIMEOUT, CREATE_CONTEXT)
+ * Utility function to setup a "main loop" for async operations.
+ * Will fail if a loop is already alive and current.
+ *
+ * return 0 on success
+ */
+int gattlib_async_setup_currentloop(int timeout, gboolean useOwnContext) {
+	DEBUG_GATTLIB("setting up async loop...");
+	if (gattlib_async_global_state.current_loop) {
+		DEBUG_GATTLIB("boo, already done\n");
+		return 1;
+	}
+	if (useOwnContext == TRUE) {
+
+		DEBUG_GATTLIB("with own context.\n");
+		gattlib_async_global_state.current_context = g_main_context_new();
+		gattlib_async_global_state.current_loop = g_main_loop_new(
+				gattlib_async_global_state.current_context, TRUE);
+	} else {
+		DEBUG_GATTLIB("with global context.\n");
+		gattlib_async_global_state.current_loop = g_main_loop_new(NULL, TRUE);
+	}
+
+
+	if (! gattlib_async_global_state.current_loop) {
+		ERROR_GATTLIB("async loop setup: could not get new loop??\n");
+		return 1;
+	}
+	if (timeout) {
+		DEBUG_GATTLIB("Adding a timeout to loop of %i seconds\n", timeout);
+
+		gattlib_async_global_state.timeout_source = g_timeout_source_new_seconds(timeout);
+		g_source_set_callback (gattlib_async_global_state.timeout_source,
+								gattlib_timeout_async_loop,
+								gattlib_async_global_state.current_loop,
+								NULL);
+
+		g_source_attach(gattlib_async_global_state.timeout_source,
+						g_main_loop_get_context(gattlib_async_global_state.current_loop));
+
+	}
+
+	DEBUG_GATTLIB("setup curloop done\n");
+	return 0;
+}
+
+/*
+ * gattlib_async_triggerandclear_donecallback()
+ * Utility function to trigger any user-specified "async done" callback,
+ * and clear it from the state.
+ */
+static void gattlib_async_triggerandclear_donecallback() {
+
+	gattlib_async_completed_cb_t dcb = gattlib_async_global_state.done_callback;
+	gattlib_async_global_state.done_callback = NULL;
+
+	if (dcb) {
+		(dcb)();
+	} else {
+		DEBUG_GATTLIB("no done cb to trigger\n");
+	}
+}
+
+/*
+ * gattlib_async_teardown_currentloop()
+ * Converse of gattlib_async_setup_currentloop() -- destroys and
+ * clears out the current main loop from async state.
+ *
+ * Side effect: will trigger done callback if it's set.
+ */
+static void gattlib_async_teardown_currentloop() {
+
+	DEBUG_GATTLIB("teardown async loop...");
+	if (!gattlib_async_global_state.current_loop) {
+		DEBUG_GATTLIB("boo, no loop\n");
+		return;
+	}
+
+	g_main_loop_quit(gattlib_async_global_state.current_loop); // TEST
+
+	if (gattlib_async_global_state.timeout_source) {
+		g_source_unref(gattlib_async_global_state.timeout_source);
+		gattlib_async_global_state.timeout_source = NULL;
+	}
+
+	g_main_loop_unref(gattlib_async_global_state.current_loop);
+	gattlib_async_global_state.current_loop = NULL;
+
+	if (gattlib_async_global_state.current_context) {
+		g_main_context_unref(gattlib_async_global_state.current_context);
+		gattlib_async_global_state.current_context = NULL;
+	}
+
+	if (gattlib_async_global_state.cleanup) {
+		(gattlib_async_global_state.cleanup)();
+		gattlib_async_global_state.cleanup = NULL;
+	}
+
+
+	DEBUG_GATTLIB("teardown trigger done cb()\n");
+
+	gattlib_async_triggerandclear_donecallback();
+
+	DEBUG_GATTLIB("teardown done\n");
+
+}
+
+/*
+ * gattlib_async_process()
+ *
+ * Allots a time slice to process events for currently setup
+ * async main loop.
+ */
+int gattlib_async_process() {
+
+	// always tick the main context, so bluez signals can get through
+	g_main_context_iteration(NULL, FALSE);
+
+	if (!gattlib_async_global_state.current_loop) {
+
+		return 1;
+	}
+
+	// DEBUG_GATTLIB("!");
+	if (!g_main_loop_is_running(gattlib_async_global_state.current_loop)) {
+		DEBUG_GATTLIB("loop run done\n");
+		gattlib_async_teardown_currentloop();
+		return 1;
+	}
+
+	g_main_context_iteration(
+			g_main_loop_get_context(gattlib_async_global_state.current_loop),
+			FALSE);
+
+	return 0;
+
+}
+
+/*
+ * gattlib_async_process_all()
+ * Similar to gattlib_async_process() but will process events until
+ * no more are pending in the current loop.
+ */
+int gattlib_async_process_all() {
+
+	// always tick the main context, so bluez signals can get through
+	g_main_context_iteration(NULL, FALSE);
+	if (!gattlib_async_global_state.current_loop) {
+		return 1 ;
+	}
+
+	gboolean moreToProcess = TRUE;
+
+	while ( gattlib_async_global_state.current_loop && (moreToProcess == TRUE)) {
+		gattlib_async_process();
+		if (gattlib_async_global_state.current_loop) {
+			moreToProcess = g_main_context_pending(g_main_loop_get_context(gattlib_async_global_state.current_loop));
+		}
+	}
+
+	return 0;
+}
+
+
+
+
+
+static void gattlib_async_scan_cleanup(void) {
+	DEBUG_GATTLIB("\nasync scan cleanup... ");
+	GDBusObjectManager *device_manager = gattlib_async_global_state.async_proc_data;
+	if (device_manager) {
+
+		DEBUG_GATTLIB("freeing device manager\n");
+		g_object_unref(device_manager);
+		gattlib_async_global_state.async_proc_data = NULL;
+	} else {
+		DEBUG_GATTLIB("no device manager to free\n");
+	}
+	DEBUG_GATTLIB("am_scanning = FALSE\n");
+	gattlib_async_global_state.am_scanning = FALSE;
+}
+
+int gattlib_adapter_scan_enable_async(void* adapter, gattlib_discovered_device_t discovered_device_cb, int timeout, gattlib_async_completed_cb_t done_cb) {
+
+	GDBusObjectManager *device_manager;
+
+	DEBUG_GATTLIB("\nscan_enable_async called...");
+	if (gattlib_async_setup_currentloop(timeout, GATTLIB_ASYNC_LOOP_CREATECONTEXT)) {
+		// gattlib_async_scan_cleanup();
+
+		DEBUG_GATTLIB("but there's a loop running already.\n");
+		return 1;
+	}
+
+
+	DEBUG_GATTLIB("(am_scanning = TRUE)\n");
+	int setupReturn = gattlib_adapter_scan_enable_setup(adapter, discovered_device_cb, &device_manager);
+	if (setupReturn)
+	{
+		DEBUG_GATTLIB("but scan setup failed.\n");
+		return setupReturn;
+	}
+
+
+	gattlib_async_global_state.am_scanning = TRUE;
+	gattlib_async_global_state.cleanup = gattlib_async_scan_cleanup;
+	gattlib_async_global_state.done_callback = done_cb;
+
+	gattlib_async_global_state.async_proc_data = device_manager;
+
+	DEBUG_GATTLIB("and we're go!\n");
+
+	return 0;
+
+
+}
+
+
+
+static
+void gattlib_async_scandisable_ready_cb(GObject *source_object,
+                        GAsyncResult *res,
+                        gpointer user_data) {
+
+	DEBUG_GATTLIB("\nhah! gattlib_async_scandisable_ready_cb called\n");
+	gattlib_async_quit_currentloop();
+	// gattlib_async_triggerandclear_donecallback();
+}
+
+
+int gattlib_adapter_scan_disable_async(void* adapter, gattlib_async_completed_cb_t done_cb) {
+
+	// likely we're scanning now
+	DEBUG_GATTLIB("\nscan disable async called...");
+
+	if (gattlib_async_global_state.current_loop && gattlib_async_global_state.am_scanning) {
+		DEBUG_GATTLIB("while scanning... quitting current loop\n");
+		gattlib_async_global_state.done_callback = NULL; // cancel that
+		gattlib_async_quit_currentloop();
+		gattlib_async_process(); // do one run to clean it out.
+
+	}
+
+
+	DEBUG_GATTLIB("scan disable prep done, calling stop discovery.\n");
+	gattlib_async_global_state.done_callback = done_cb;
+	gattlib_async_setup_currentloop(20, GATTLIB_ASYNC_LOOP_CREATECONTEXT);
+	org_bluez_adapter1_call_stop_discovery((OrgBluezAdapter1*)adapter, NULL,
+			gattlib_async_scandisable_ready_cb, NULL);
+	return 0;
+}
+
+
+
+
+
+
+/* gattlib_connect_params_t
+ * used to pack all our async connect() call params
+ * into a single spot, for easier management
+ */
+typedef struct {
+	char *src;
+	char *dst;
+	uint8_t dest_type;
+	gattlib_bt_sec_level_t sec_level;
+	int psm;
+	int mtu;
+} gattlib_connect_params_t;
+
+/*
+ * Async connection functions... this may be more complex than required,
+ * but the connect_async() stuff was created using a glib task, so it involves
+ * a whole bunch-o-functions working together... bitofamess.
+ */
+static void gattlib_async_connect_trigger_conn_cb(gatt_connection_t * connptr) {
+
+	if (gattlib_async_global_state.connection_done_cb) {
+		DEBUG_GATTLIB("gotta conn cb to call!\n");
+		gatt_connect_cb_t thecb = gattlib_async_global_state.connection_done_cb;
+		gattlib_async_global_state.done_callback = NULL;
+		/* teardown the current loop immediately, in case the callback wants to
+		 * set another async op up.
+		 */
+		gattlib_async_teardown_currentloop();
+		gattlib_async_global_state.connection_done_cb = NULL;
+		thecb(connptr);
+	}
+
+}
+
+static void gattlib_async_connect_timeouttrigger_conn_cb() {
+	gattlib_async_global_state.done_callback = NULL; // clear it out.
+	gattlib_async_connect_trigger_conn_cb(NULL);
+}
+
+static void gattlib_connect_thread_data_free(void * dptr) {
+	gattlib_connect_params_t *data = dptr;
+	if (data->src) {
+		free(data->src);
+	}
+	if (data->dst) {
+		free(data->dst);
+	}
+	g_free(data);
+}
+static void gattlib_connect_destroy_unclaimed_connection(gpointer data) {
+
+	DEBUG_GATTLIB("gattlib_connect_destroy_unclaimed_connection\n");
+	gatt_connection_t * conn = data;
+	if (conn) {
+		gattlib_disconnect(conn);
+	}
+
+}
+static void gattlib_connect_thread_cb(GTask *task, gpointer source_object,
+		gpointer task_data, GCancellable *cancellable) {
+	DEBUG_GATTLIB("connect thread_cb launched\n");
+	gattlib_connect_params_t *data = task_data;
+	gatt_connection_t * retval;
+
+	/* Handle cancellation. */
+	if (g_task_return_error_if_cancelled(task)) {
+		return;
+	}
+
+	/* Run the blocking function. */
+	retval = gattlib_connect(data->src, data->dst, data->dest_type,
+			data->sec_level, data->psm, data->mtu);
+
+	if (!retval) {
+		DEBUG_GATTLIB("async conn returned nuffin' !!!\n");
+		// gattlib_async_connect_trigger_conn_cb(NULL);
+
+	}
+	g_task_return_pointer(task, retval,
+			gattlib_connect_destroy_unclaimed_connection);
+
+}
+
+void gattlib_connect_async_glib(const char *src, const char *dst,
+		uint8_t dest_type, gattlib_bt_sec_level_t sec_level, int psm, int mtu,
+		/* gatt_connect_cb_t connect_cb, */
+		GCancellable *cancellable, GAsyncReadyCallback callback,
+		gpointer user_data) {
+	GTask *task = NULL; /* owned */
+	gattlib_connect_params_t *data = NULL; /* owned */
+
+	DEBUG_GATTLIB("gattlib_connect_async_glib\n");
+
+	/* g_return_if_fail (src && strlen(src)); */
+	/* g_return_if_fail (dst && strlen(dst)); */
+	g_return_if_fail(cancellable == NULL || G_IS_CANCELLABLE (cancellable));
+
+	task = g_task_new(NULL, cancellable, callback, user_data);
+	g_task_set_source_tag(task, gattlib_connect_async_glib);
+
+	/* Cancellation should be handled manually using mechanisms specific to
+	 * some_blocking_function(). */
+	g_task_set_return_on_cancel(task, FALSE);
+
+	/* Set up a closure containing the call’s parameters. Copy them to avoid
+	 * locking issues between the calling thread and the worker thread. */
+	data = g_new0(gattlib_connect_params_t, 1);
+	if (src) {
+		data->src = malloc(strlen(src) + 1);
+		if (data->src) {
+			strcpy(data->src, src);
+		}
+	}
+
+	if (dst) {
+		data->dst = malloc(strlen(dst) + 1);
+		if (data->dst) {
+			strcpy(data->dst, dst);
+		}
+	}
+	data->dest_type = dest_type;
+	data->sec_level = sec_level;
+	data->psm = psm;
+	data->mtu = mtu;
+	/* data->connect_cb = connect_cb; */
+
+	g_task_set_task_data(task, data, gattlib_connect_thread_data_free);
+
+	/* Run the task in a worker thread and return immediately while that continues
+	 * in the background. When it’s done it will call @callback in the current
+	 * thread default main context. */
+	g_task_run_in_thread(task, gattlib_connect_thread_cb);
+
+	g_object_unref(task);
+}
+
+gatt_connection_t *
+gattlib_connect_async_finish(GAsyncResult *result, GError **error) {
+	DEBUG_GATTLIB("gattlib_connect_async_finish\n");
+	g_return_val_if_fail(g_task_is_valid(result, gattlib_connect_async_glib),
+			NULL);
+	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
+
+	return g_task_propagate_pointer(G_TASK(result), error);
+}
+
+static
+void gattlib_async_connect_ready_cb(GObject *source_object, GAsyncResult *res,
+		gpointer user_data) {
+	GError *error = NULL;
+	gatt_connection_t * connptr;
+	DEBUG_GATTLIB("gattlib_async_connect_ready_cb\n");
+	if (gattlib_async_global_state.connection_done_cb) {
+		connptr = g_task_propagate_pointer(G_TASK(res), &error);
+		gattlib_async_connect_trigger_conn_cb(connptr);
+	}
+
+}
+
+int gattlib_connect_async(const char *src, const char *dst, uint8_t dest_type,
+		gattlib_bt_sec_level_t sec_level, int psm, int mtu,
+		gatt_connect_cb_t connect_cb) {
+
+	DEBUG_GATTLIB("gattlib_connect_async\n");
+	gattlib_async_global_state.connection_done_cb = connect_cb;
+	gattlib_async_global_state.done_callback = gattlib_async_connect_timeouttrigger_conn_cb;
+
+	gattlib_async_setup_currentloop(8, GATTLIB_ASYNC_LOOP_CREATECONTEXT);
+	gattlib_connect_async_glib(src, dst, dest_type, sec_level, psm, mtu, NULL,
+			gattlib_async_connect_ready_cb, NULL);
+	return 0;
+
+}
+
+
+static void gattlib_async_disconnect_ready_cb(GObject *source_object,
+		GAsyncResult *res, gpointer user_data) {
+
+	DEBUG_GATTLIB("\nhah! gattlib_async_disconnect_ready_cb called, freeing stuffz\n");
+	gatt_connection_t* connection = user_data;
+	if (connection) {
+		gattlib_context_t* conn_context = connection->context;
+
+		free(conn_context->device_object_path);
+		g_object_unref(conn_context->device);
+
+		free(connection->context);
+		free(connection);
+	}
+
+	gattlib_async_quit_currentloop();
+}
+
+int gattlib_disconnect_async(gatt_connection_t* connection,
+		gattlib_async_completed_cb_t done_cb) {
+	DEBUG_GATTLIB("disconn (async)!\n");
+
+	if (!connection) {
+		DEBUG_GATTLIB("boo, no connection!\n");
+		return 1;
+	}
+	gattlib_async_global_state.done_callback = done_cb;
+	gattlib_context_t* conn_context = connection->context;
+
+	if (gattlib_async_setup_currentloop(20, GATTLIB_ASYNC_LOOP_CREATECONTEXT)) {
+		DEBUG_GATTLIB("boo, can't setup mainloop!\n");
+		return 1;
+	}
+
+	org_bluez_device1_call_disconnect(conn_context->device, NULL,
+			gattlib_async_disconnect_ready_cb, connection);
+
+	return 0;
+}
+
+
+
+
+int gattlib_read_char_by_uuid_async(gatt_connection_t* connection, uuid_t* uuid, gatt_read_cb_t gatt_read_cb) {
+	OrgBluezGattCharacteristic1 *characteristic = get_characteristic_from_uuid(uuid);
+	if (characteristic == NULL) {
+		return -1;
+	}
+
+	GVariant *out_value;
+	GError *error = NULL;
+
+#if BLUEZ_VERSION < BLUEZ_VERSIONS(5, 40)
+	org_bluez_gatt_characteristic1_call_read_value_sync(
+		characteristic, &out_value, NULL, &error);
+#else
+	GVariantBuilder *options =  g_variant_builder_new(G_VARIANT_TYPE("a{sv}"));
+	org_bluez_gatt_characteristic1_call_read_value_sync(
+		characteristic, g_variant_builder_end(options), &out_value, NULL, &error);
+	g_variant_builder_unref(options);
+#endif
+	if (error != NULL) {
+		return -1;
+	}
+
+	gsize n_elements;
+	gconstpointer const_buffer = g_variant_get_fixed_array(out_value, &n_elements, sizeof(guchar));
+	if (const_buffer) {
+		gatt_read_cb(const_buffer, n_elements);
+	}
+
+	g_object_unref(characteristic);
+
+#if BLUEZ_VERSION >= BLUEZ_VERSIONS(5, 40)
+	//g_variant_unref(in_params); See: https://github.com/labapart/gattlib/issues/28#issuecomment-311486629
+#endif
+	return 0;
+}
+
+
+static
+void gattlib_async_write_ready_cb(GObject *source_object,
+                        GAsyncResult *res,
+                        gpointer user_data) {
+
+	DEBUG_GATTLIB("\nhah! gattlib_async_write_ready_cb called ");
+	GError *error = NULL;
+
+	if (org_bluez_gatt_characteristic1_call_write_value_finish(
+			gattlib_async_global_state.async_proc_data, res, &error) == FALSE) {
+
+		DEBUG_GATTLIB("but had error. %s\n", error->message);
+		if (gattlib_async_global_state.error_callback)
+		{
+			gattlib_async_global_state.done_callback = gattlib_async_global_state.error_callback;
+			gattlib_async_global_state.error_callback = NULL;
+		}
+	} else {
+
+		DEBUG_GATTLIB("and lookin good.\n");
+	}
+
+	if ( gattlib_async_global_state.async_proc_data) {
+		g_object_unref(gattlib_async_global_state.async_proc_data);
+		gattlib_async_global_state.async_proc_data = NULL;
+	}
+
+
+	gattlib_async_quit_currentloop();
+
+
+
+}
+
+
+int gattlib_write_char_by_uuid_async(gatt_connection_t* connection, uuid_t* uuid, const void* buffer, size_t buffer_len,
+		gattlib_async_completed_cb_t done_cb, gattlib_async_error_cb_t error_cb) {
+
+	DEBUG_GATTLIB("write_by_uuid (async)!\n");
+
+	if (!connection) {
+		DEBUG_GATTLIB("boo, no connection!\n");
+		if (error_cb) {
+			error_cb();
+		}
+		return 1;
+	}
+
+	OrgBluezGattCharacteristic1 *characteristic = get_characteristic_from_uuid(uuid);
+	if (characteristic == NULL) {
+
+		DEBUG_GATTLIB("\nwrite() can't find this characteristic!\n");
+		if (error_cb) {
+			error_cb();
+		}
+		return -1;
+	}
+
+	GVariant *value = g_variant_new_from_data(G_VARIANT_TYPE ("ay"), buffer, buffer_len, TRUE, NULL, NULL);
+
+	gattlib_async_global_state.error_callback = error_cb;
+	gattlib_async_global_state.done_callback = done_cb;
+	gattlib_async_global_state.async_proc_data = characteristic;
+	gattlib_async_setup_currentloop(10, GATTLIB_ASYNC_LOOP_CREATECONTEXT);
+#if BLUEZ_VERSION < BLUEZ_VERSIONS(5, 40)
+	org_bluez_gatt_characteristic1_call_write_value(characteristic, value, NULL, NULL, gattlib_async_write_ready_cb, NULL);
+#else
+	GVariantBuilder *options =  g_variant_builder_new(G_VARIANT_TYPE("a{sv}"));
+	org_bluez_gatt_characteristic1_call_write_value(characteristic, value, g_variant_builder_end(options), NULL, gattlib_async_write_ready_cb, NULL);
+	g_variant_builder_unref(options);
+#endif
+
+#if BLUEZ_VERSION >= BLUEZ_VERSIONS(5, 40)
+	//g_variant_unref(in_params); See: https://github.com/labapart/gattlib/issues/28#issuecomment-311486629
+#endif
+	return 0;
+}
+
+
+
+
+

--- a/dbus/gattlib_internal.h
+++ b/dbus/gattlib_internal.h
@@ -23,7 +23,7 @@
 
 #ifndef __GATTLIB_INTERNAL_H__
 #define __GATTLIB_INTERNAL_H__
-
+#include <stdio.h>
 #include "gattlib.h"
 
 #include "org-bluez-adaptater1.h"
@@ -41,5 +41,21 @@ typedef struct {
 	char* device_object_path;
 	OrgBluezDevice1* device;
 } gattlib_context_t;
+
+
+
+
+
+/* define GATTLIB_DEBUG_OUTPUT_ENABLE */
+
+#ifdef GATTLIB_DEBUG_OUTPUT_ENABLE
+#define DEBUG_GATTLIB(...) fprintf(stderr, __VA_ARGS__)
+#else
+#define DEBUG_GATTLIB(...)
+#endif
+
+#define ERROR_GATTLIB(...) 		fprintf(stderr, __VA_ARGS__)
+
+OrgBluezGattCharacteristic1 *get_characteristic_from_uuid(const uuid_t* uuid);
 
 #endif

--- a/examples/ble_scan_async/CMakeLists.txt
+++ b/examples/ble_scan_async/CMakeLists.txt
@@ -1,0 +1,36 @@
+#
+#  BLE scan async example
+#
+#  Copyright (C) 2017 Pat Deegan, psychogenic.com
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+
+cmake_minimum_required(VERSION 2.6)
+
+find_package(PkgConfig REQUIRED)
+
+pkg_search_module(GATTLIB REQUIRED gattlib)
+
+# Added Glib support to ensure we have 'glib loops'
+pkg_search_module(GLIB REQUIRED glib-2.0)
+
+include_directories(${GLIB_INCLUDE_DIRS})
+
+set(ble_scan_async_SRCS ble_scan_async.c)
+
+add_executable(ble_scan_async ${ble_scan_async_SRCS})
+target_link_libraries(ble_scan_async ${GATTLIB_LDFLAGS} ${GLIB_LDFLAGS} pthread)

--- a/examples/ble_scan_async/ble_scan_async.c
+++ b/examples/ble_scan_async/ble_scan_async.c
@@ -1,0 +1,291 @@
+/*
+ * ble_scan_async
+ *
+ * Copyright (C) 2017 Pat Deegan, psychogenic.com
+ *
+ *
+ * Look 'ma, no threads!
+ *
+ * This is an async version of the ble_scan example, using relevant
+ * async calls to scan/connect, and callbacks to implement the logic.
+ *
+ * The point of this sample is that threads could be used, 
+ * for instance to drive the process_async() calls, but aren't 
+ * required in order to get on with other business while the BLE 
+ * stuff is happening in the background.
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#include <pthread.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <sys/queue.h>
+#include <unistd.h>
+#include "gattlib.h"
+
+
+#define BLE_SCAN_TIMEOUT   5
+#define MAINLOOP_SLEEP_US 10000
+
+typedef void (*ble_discovered_device_t)(const char* addr, const char* name);
+
+
+LIST_HEAD(listhead, connection_t) g_ble_connections;
+struct connection_t {
+	pthread_t thread;
+	char* addr;
+	LIST_ENTRY(connection_t) entries;
+};
+
+/*
+ * ble_discovered_device -- callback used by scan to report devices.
+ * Simply adds the device to our g_ble_connections list.
+ */
+static void ble_discovered_device(const char* addr, const char* name) {
+	struct connection_t *connection;
+
+	if (name) {
+		fprintf(stderr, "Discovered %s - '%s'\n", addr, name);
+	} else {
+		fprintf(stderr, "Discovered %s\n", addr);
+	}
+
+	connection = malloc(sizeof(struct connection_t));
+	if (connection == NULL) {
+		fprintf(stderr, "Failed to allocate connection.\n");
+		return;
+	}
+	connection->addr = strdup(addr);
+
+	LIST_INSERT_HEAD(&g_ble_connections, connection, entries);
+}
+
+
+
+/*
+ * adapter -- global used to store pointer to the BLE adapter
+ */
+void* adapter = NULL;
+
+/*
+ * AllDone -- global flag to indicate
+ * program is finished.
+ */
+int AllDone = 0;
+
+/* forward decl */
+void connectAndDiscoverNext();
+
+/* clear out connection from our list, once handled */
+void removeCurrentConnectionFromList() {
+		struct connection_t * connection = g_ble_connections.lh_first;
+		LIST_REMOVE(g_ble_connections.lh_first, entries);
+		free(connection->addr);
+		free(connection);
+}
+
+/* process next scanned device */
+void connectionMoveToNext() {
+
+	removeCurrentConnectionFromList();
+	connectAndDiscoverNext();
+}
+
+/* async connection completed callback: discovers the services
+ * and chars of a device, after connection is established.
+ *
+ * This function actually calls blocking versions of the discovery
+ * functions, as
+ * 	a) I have yet to actually implement async versions;
+ * 	b) using async versions would make the string of callbacks/async
+ * 	   calls pretty unweildy; and
+ * 	c) they seem pretty fast in any case.
+ *
+ * It does, however, use the async disconnect function, with it's callback
+ * triggering the next connection+discovery.
+ */
+void connectionEstablishedCb(gatt_connection_t* gatt_connection) {
+	gattlib_primary_service_t* services;
+	gattlib_characteristic_t* characteristics;
+	int services_count, characteristics_count;
+	char uuid_str[MAX_LEN_UUID_STR + 1];
+	int ret, i;
+
+	if (! gatt_connection) {
+		connectionMoveToNext();
+		return;
+	}
+
+	struct connection_t* connection = g_ble_connections.lh_first;
+
+	char* addr = connection->addr;
+
+	fprintf(stderr, "\n------------START %s ---------------\n", addr);
+
+	ret = gattlib_discover_primary(gatt_connection, &services, &services_count);
+	if (ret != 0) {
+		fprintf(stderr, "Fail to discover primary services.\n");
+		goto disconnect_exit;
+	}
+
+	for (i = 0; i < services_count; i++) {
+		gattlib_uuid_to_string(&services[i].uuid, uuid_str, sizeof(uuid_str));
+
+		fprintf(stderr, "service[%d] start_handle:%02x end_handle:%02x uuid:%s\n", i,
+				services[i].attr_handle_start, services[i].attr_handle_end,
+				uuid_str);
+	}
+	free(services);
+
+	ret = gattlib_discover_char(gatt_connection, &characteristics, &characteristics_count);
+	if (ret != 0) {
+		fprintf(stderr, "Fail to discover characteristics.\n");
+		goto disconnect_exit;
+	}
+	for (i = 0; i < characteristics_count; i++) {
+		gattlib_uuid_to_string(&characteristics[i].uuid, uuid_str, sizeof(uuid_str));
+
+		fprintf(stderr, "characteristic[%d] properties:%02x value_handle:%04x uuid:%s\n", i,
+				characteristics[i].properties, characteristics[i].value_handle,
+				uuid_str);
+	}
+	free(characteristics);
+
+disconnect_exit:
+	gattlib_disconnect_async(gatt_connection, connectionMoveToNext);
+	fprintf(stderr, "------------DONE %s ---------------\n", addr);
+
+	
+}
+
+/*
+ * connectAndDiscoverNext connect to, and then discover chars,
+ * for next ble device in list.
+ *
+ */
+void connectAndDiscoverNext() {
+
+	if (g_ble_connections.lh_first == NULL) {
+		AllDone = 1;
+		fprintf(stderr, "No more connections to scan");
+		return;
+	}
+
+	struct connection_t* connection = g_ble_connections.lh_first;
+
+	char* addr = connection->addr;
+
+	fprintf(stderr, "\nDoing async conn to next... @ %s\n" , addr);
+	/* call async connect with connectionEstablishedCb callback */
+	gattlib_connect_async(NULL, addr, BDADDR_LE_PUBLIC,
+			BT_SEC_LOW, 0, 0, connectionEstablishedCb);
+
+
+}
+
+/*
+ * scanDisabledCb -- called when scan is turned off,
+ * triggers the start of connection+discovery chain.
+ */
+void scanDisabledCb() {
+	fprintf(stderr, "\nscan now disabled!\n");
+	connectAndDiscoverNext();
+}
+
+/*
+ * scanCompleteCb -- called when our
+ * async scanning interval times out, and calls
+ * async scan disable.
+ *
+ */
+void scanCompleteCb() {
+	fprintf(stderr, "\nscanCompleteCb! startup scan disable\n");
+	gattlib_adapter_scan_disable_async(adapter, scanDisabledCb);
+}
+
+
+int main(int argc, const char *argv[]) {
+	const char* adapter_name;
+	int ret;
+
+	if (argc == 1) {
+		adapter_name = NULL;
+	} else if (argc == 2) {
+		adapter_name = argv[1];
+	} else {
+		fprintf(stderr, "%s [<bluetooth-adapter>]\n", argv[0]);
+		return 1;
+	}
+
+	LIST_INIT(&g_ble_connections);
+
+	/* open the adapter */
+	ret = gattlib_adapter_open(adapter_name, &adapter);
+	if (ret) {
+		fprintf(stderr, "ERROR: Failed to open adapter.\n");
+		return 1;
+	}
+
+	/*
+	 * Could use a state machine or whatever, but to keep things
+	 * simple and demo the async stuff, we've setup a chain of
+	 * callbacks, above.  Each one will trigger the next step.
+	 *
+	 * To get the ball rolling, we start by scanning the environment,
+	 * with an async call to scan_enable.  It will keep scanning
+	 * until BLE_SCAN_TIMEOUT expires, then trigger its "done
+	 * callback", which will in turn call async scan_disable, etc.
+	 */
+
+	ret = gattlib_adapter_scan_enable_async(adapter,
+				ble_discovered_device, BLE_SCAN_TIMEOUT, scanCompleteCb);
+
+	/*
+	 * Now comes our main loop.  In this toy example, I don't have much to
+	 * do, but this is where you'd process user events, UI stuff, whatever.
+	 *
+	 * In this case, all we do is call one of the async_process functions,
+	 * output the occasional character just to show we're still running, and
+	 * spend lots of time sleeping.
+	 *
+	 * The point is that this loop is simple, with all the heavy lifting
+	 * happening in callbacks, and no threads needed in this code.
+	 */
+	int counter = 0;
+	while (! AllDone) {
+		/* could do gattlib_async_process_all(), but since we're looping 'often' we
+		 * just call:
+		 */
+
+		gattlib_async_process();
+
+		if (counter++ == 5)
+		{
+			fprintf(stderr, "o");
+		} else if (counter == 10 ) {
+			counter = 0;
+			fprintf(stderr, "O");
+		}
+		usleep(MAINLOOP_SLEEP_US);
+	}
+
+	fprintf(stderr, "\n\nOk, we're all done!\nGoodbye\n");
+	gattlib_adapter_close(adapter);
+	return 0;
+}


### PR DESCRIPTION
These mods provide async versions of scan/connect/read-write related functions.  Though I moved some things around in the original sync versions, they are left as-is.

Caveats and limitations:
 1) though the calls provided are asynchronous, they are limited to being called one at a time (e.g. if you read a characteristic, you need to wait until you get an answer, or a failure, callback before writing another).

 2) I didn't want to impose any kind of threading model on the system, so you need to "tick" the system for the async functions to work.  This can be done in a main loop, a thread, whatever you want, and the callbacks will be triggered in the given context.

Note: I know neither bluez nor glib, so the implementation is a bit hacky and may not be ideal... suggestions/improvements welcome.

Regards,
Pat Deegan