### PR TITLE
Maybe fix for a couple of bugs in write descriptors:

### DIFF
--- a/bluez/gattlib_read_write.c
+++ b/bluez/gattlib_read_write.c
@@ -193,8 +193,7 @@ int gattlib_write_char_by_uuid(gatt_connection_t* connection, uuid_t* uuid, cons
 		fprintf(stderr, "Fail to find handle for UUID.\n");
 		return ret;
 	}
-
-	return gattlib_write_char_by_handle(connection, handle, buffer, sizeof(buffer));
+	return gattlib_write_char_by_handle(connection, handle, buffer, buffer_len);
 }
 
 int gattlib_notification_start(gatt_connection_t* connection, const uuid_t* uuid) {

--- a/examples/read_write/read_write.c
+++ b/examples/read_write/read_write.c
@@ -24,7 +24,6 @@
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
-
 #include "gattlib.h"
 
 typedef enum { READ, WRITE} operation_t;
@@ -53,7 +52,7 @@ int main(int argc, char *argv[]) {
 	} else if ((strcmp(argv[2], "write") == 0) && (argc == 5)) {
 		g_operation = WRITE;
 
-		if ((strlen(argv[4]) >= 2) && (argv[4][0] == '0') && (argv[4][0] == 'x')) {
+		if ((strlen(argv[4]) >= 2) && (argv[4][0] == '0') && ((argv[4][1] == 'x') || (argv[4][1] == 'X'))) {
 			value_data = strtol(argv[4], NULL, 0);
 		} else {
 			value_data = strtol(argv[4], NULL, 16);
@@ -69,7 +68,7 @@ int main(int argc, char *argv[]) {
 		return 1;
 	}
 
-	connection = gattlib_connect(NULL, argv[1], BDADDR_LE_PUBLIC, BT_SEC_LOW, 0, 0);
+	connection = gattlib_connect(NULL, argv[1], BDADDR_LE_RANDOM, BT_SEC_LOW, 0, 0);
 	if (connection == NULL) {
 		fprintf(stderr, "Fail to connect to the bluetooth device.\n");
 		return 1;
@@ -85,8 +84,11 @@ int main(int argc, char *argv[]) {
 			printf("%02x ", buffer[i]);
 		printf("\n");
 	} else {
-		ret = gattlib_write_char_by_uuid(connection, &g_uuid, buffer, sizeof(buffer));
+      buffer[0] = (uint8_t) value_data;
+      buffer[1] = '\0';
+		ret = gattlib_write_char_by_uuid(connection, &g_uuid,buffer,1);
 		assert(ret == 0);
+      printf("Write UUID completed: ");
 	}
 
 	gattlib_disconnect(connection);


### PR DESCRIPTION
1) In the read_write example, in a write to descriptor, the buffer is never written with the value to write.

2) In /bluez/gattlib_read_write.c the sizeof the pointer is used rather than the length of the buffer when writing the descriptor

I think there may still be problems in the read write example with regard to the  type of the value you wish to write.
In my case it is a uint8_t. I used the example here
https://github.com/sandeepmistry/arduino-BLEPeripheral/blob/master/examples/led/led.ino

Anyway with the version in my branch I can now write the value correctly, but probably needs work to be generic.