### PR TITLE
bugfix: Passing user provided pointer to notification handler

### DIFF
--- a/dbus/gattlib.c
+++ b/dbus/gattlib.c
@@ -928,7 +928,7 @@ gboolean on_handle_characteristic_property_change(
 							MAX_LEN_UUID_STR + 1,
 							&uuid);
 
-					connection->notification_handler(&uuid, data, data_length, user_data);
+					connection->notification_handler(&uuid, data, data_length, connection->notification_user_data);
 					break;
 				}
 			}


### PR DESCRIPTION
Instead of connection object pointer, user should receive pointer to context it registered in gattlib_register_notification

i.e. Notification handler wasn't receiving same object that was registered.