### PR TITLE
bluez: Fix buffer length in gattlib_write_char_by_uuid()

### DIFF
--- a/bluez/gattlib_read_write.c
+++ b/bluez/gattlib_read_write.c
@@ -193,7 +193,7 @@ int gattlib_write_char_by_uuid(gatt_connection_t* connection, uuid_t* uuid, cons
 		return ret;
 	}
 
-	return gattlib_write_char_by_handle(connection, handle, buffer, sizeof(buffer));
+	return gattlib_write_char_by_handle(connection, handle, buffer, buffer_len);
 }
 
 int gattlib_notification_start(gatt_connection_t* connection, const uuid_t* uuid) {


### PR DESCRIPTION
Issue found by @kwikius in #74 and @mweal-ed in #35.