### PR TITLE
dbus: Add support for Bluez Battery Profile

### DIFF
--- a/dbus/CMakeLists.txt
+++ b/dbus/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 #  GattLib - GATT Library
 #
-#  Copyright (C) 2017  Olivier Martin <olivier@labapart.org>
+#  Copyright (C) 2017-2019  Olivier Martin <olivier@labapart.org>
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -70,12 +70,19 @@ add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/org-bluez-gattdescriptor1.
                    COMMENT "Generate D-Bus 'org.bluez.GattDescriptor1.xml'"
                    )
 
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/org-bluez-battery1.c
+                   COMMAND gdbus-codegen --interface-prefix org.bluez.Battery1. --generate-c-code ${CMAKE_CURRENT_BINARY_DIR}/org-bluez-battery1 ${CMAKE_CURRENT_SOURCE_DIR}/${DBUS_BLUEZ_API}/org.bluez.Battery1.xml
+                   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${DBUS_BLUEZ_API}/org.bluez.Battery1.xml
+                   COMMENT "Generate D-Bus 'org.bluez.Battery1.xml'"
+                   )
+
 include_directories(. ${CMAKE_CURRENT_BINARY_DIR} ${GIO_UNIX_INCLUDE_DIRS} ${BLUEZ_INCLUDE_DIRS})
 
 set(gattlib_SRCS gattlib.c
                  bluez5/lib/uuid.c
                  ../gattlib_common.c
                  ${CMAKE_CURRENT_BINARY_DIR}/org-bluez-adaptater1.c
+                 ${CMAKE_CURRENT_BINARY_DIR}/org-bluez-battery1.c
                  ${CMAKE_CURRENT_BINARY_DIR}/org-bluez-device1.c
                  ${CMAKE_CURRENT_BINARY_DIR}/org-bluez-gattcharacteristic1.c
                  ${CMAKE_CURRENT_BINARY_DIR}/org-bluez-gattdescriptor1.c

--- a/dbus/dbus-bluez-v5.40/org.bluez.Battery1.xml
+++ b/dbus/dbus-bluez-v5.40/org.bluez.Battery1.xml
@@ -1,0 +1,14 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+	"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+
+<node>
+	<interface name="org.bluez.Battery1">
+		<property name="Percentage" type="y" access="read"></property>
+
+		<signal name="PropertiesChanged">
+			<arg name="interface" type="s"/>
+			<arg name="changed_properties" type="a{sv}"/>
+			<arg name="invalidated_properties" type="as"/>
+		</signal>
+	</interface>
+</node>

--- a/dbus/gattlib_internal.h
+++ b/dbus/gattlib_internal.h
@@ -27,6 +27,7 @@
 #include "gattlib.h"
 
 #include "org-bluez-adaptater1.h"
+#include "org-bluez-battery1.h"
 #include "org-bluez-device1.h"
 #include "org-bluez-gattcharacteristic1.h"
 #include "org-bluez-gattdescriptor1.h"


### PR DESCRIPTION
Bluez v5.48 moved battery level into its own DBUS interface and hide it from the list of DBUS GATT characteristic.

This change fakes DBUS Battery interface as GATT characteristic.

Fix #84