### PR TITLE
Fix disconnection handler type check

### DIFF
--- a/common/gattlib_common.c
+++ b/common/gattlib_common.c
@@ -73,7 +73,7 @@ void gattlib_call_notification_handler(struct gattlib_handler *handler, const uu
 }
 
 void gattlib_call_disconnection_handler(struct gattlib_handler *handler) {
-	if (handler->type == NATIVE_NOTIFICATION) {
+	if (handler->type == NATIVE_DISCONNECTION) {
 		handler->disconnection_handler(handler->user_data);
 	}
 #if defined(WITH_PYTHON)


### PR DESCRIPTION
The type check for disconnection handlers was incorrectly checking for notification type, resulting in all disconnection handlers being treated as invalid. This single line change allows them to work again :)