### PR TITLE
Fixed error message in notification example app

### DIFF
--- a/examples/notification/notification.c
+++ b/examples/notification/notification.c
@@ -72,7 +72,7 @@ int main(int argc, char *argv[]) {
 
 	ret = gattlib_notification_start(connection, &g_battery_level_uuid);
 	if (ret) {
-		fprintf(stderr, "Fail to start notification\n.");
+		fprintf(stderr, "Fail to start notification.\n");
 		goto DISCONNECT;
 	}
 


### PR DESCRIPTION
Fixed a small typo in which the newline was printed one character early
in an error message.