### PR TITLE
Make building docs optional - defaults to on

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ project(gattlib)
 
 option(GATTLIB_BUILD_EXAMPLES "Build GattLib examples" YES)
 option(GATTLIB_SHARED_LIB "Build GattLib as a shared library" YES)
+option(GATTLIB_BUILD_DOCS "Build GattLib docs" YES)
 
 find_package(PkgConfig REQUIRED)
 
@@ -84,7 +85,9 @@ else()
   link_directories(${PROJECT_BINARY_DIR}/bluez)
 endif()
 
-add_subdirectory(docs)
+if(GATTLIB_BUILD_DOCS)
+  add_subdirectory(docs)
+endif()
 
 # Generate pkg-config file before building the examples
 configure_file(dbus/gattlib.pc.in ${PROJECT_BINARY_DIR}/gattlib.pc @ONLY)


### PR DESCRIPTION
Building the documentation requires Doxygen. When working on an embedded system, Doxygen may be unavailable or inconvenient to use. Optionally disabling the building of documentation solves that.