### PR TITLE
fixed 'apt-install' to 'apt install'

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Build GattLib
 
 * Gattlib requires the following packages: `libbluetooth-dev`, `libreadline-dev`.  
 On Debian based system (such as Ubuntu), you can installed these packages with the
-following command: `sudo apt-install libbluetooth-dev libreadline-dev`
+following command: `sudo apt install libbluetooth-dev libreadline-dev`
 
 ```
 cd <gattlib-src-root>


### PR DESCRIPTION
Literally replaced the dash with a space in the README.