### PR TITLE
cmake: Use GNUInstallDirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,8 @@ endif()
 #
 # List of file to install
 #
-install(FILES include/gattlib.h DESTINATION include)
-install(FILES ${PROJECT_BINARY_DIR}/gattlib.pc DESTINATION lib/pkgconfig)
+include(GNUInstallDirs)
+install(FILES include/gattlib.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(FILES ${PROJECT_BINARY_DIR}/gattlib.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
 include(CPack)

--- a/dbus/CMakeLists.txt
+++ b/dbus/CMakeLists.txt
@@ -19,7 +19,7 @@
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.0)
 
 find_package(PkgConfig REQUIRED)
 
@@ -119,4 +119,6 @@ endif()
 add_library(gattlib SHARED ${gattlib_SRCS})
 target_link_libraries(gattlib ${gattlib_LIBS})
 
-install(TARGETS gattlib LIBRARY DESTINATION lib)
+include(GNUInstallDirs)
+
+install(TARGETS gattlib LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
Helps install cmakefiles in right libdir

Signed-off-by: Khem Raj <raj.khem@gmail.com>