### PR TITLE
Fix pointer/type issues with gattlib-py

### DIFF
--- a/common/gattlib_common.c
+++ b/common/gattlib_common.c
@@ -61,7 +61,7 @@ void gattlib_call_notification_handler(struct gattlib_handler *handler, const uu
 
 		d_gstate = PyGILState_Ensure();
 
-		PyObject *arglist = Py_BuildValue("(sIIO)", uuid_str, data, data_length, handler->user_data);
+		PyObject *arglist = Py_BuildValue("(sLIO)", uuid_str, data, data_length, handler->user_data);
 		PyEval_CallObject((PyObject *)handler->notification_handler, arglist);
 
 		PyGILState_Release(d_gstate);

--- a/gattlib-py/gattlib/device.py
+++ b/gattlib-py/gattlib/device.py
@@ -140,12 +140,12 @@ class Device:
         # for i in range(data_len):
         #    value[i] = data[i]
 
-        pointer_type = POINTER(c_byte * data_len)
+        pointer_type = POINTER(c_ubyte * data_len)
         c_bytearray = cast(data, pointer_type)
 
         value = bytearray(data_len)
         for i in range(data_len):
-            value[i] = c_bytearray.contents[i] & 0xFF
+            value[i] = c_bytearray.contents[i]
 
         # Call GATT characteristic Notification callback
         characteristic_callback['callback'](value, characteristic_callback['user_data'])

--- a/gattlib-py/gattlib/gatt.py
+++ b/gattlib-py/gattlib/gatt.py
@@ -74,7 +74,7 @@ class GattCharacteristic():
 
             ret = gattlib_read_char_by_uuid(self.connection, self._gattlib_characteristic.uuid, byref(_buffer), byref(_buffer_len))
 
-            pointer_type = POINTER(c_byte * _buffer_len.value)
+            pointer_type = POINTER(c_ubyte * _buffer_len.value)
             c_bytearray = cast(_buffer, pointer_type)
 
             value = bytearray(_buffer_len.value)


### PR DESCRIPTION
Fixes an issue where data bytes in messages would throw an error when being assigned to a byte array, and prevent integer truncation from clobbering a c pointer.