### PR TITLE
Only pass pointer value as long type on 64 bit systems.

### DIFF
--- a/common/gattlib_common.c
+++ b/common/gattlib_common.c
@@ -61,7 +61,13 @@ void gattlib_call_notification_handler(struct gattlib_handler *handler, const uu
 
 		d_gstate = PyGILState_Ensure();
 
-		PyObject *arglist = Py_BuildValue("(sLIO)", uuid_str, data, data_length, handler->user_data);
+		const char* argument_string;
+		if (sizeof(void*) == 8) {
+			argument_string = "(sLIO)";
+		} else {
+			argument_string = "(sIIO)";
+		}
+		PyObject *arglist = Py_BuildValue(argument_string, uuid_str, data, data_length, handler->user_data);
 		PyEval_CallObject((PyObject *)handler->notification_handler, arglist);
 
 		PyGILState_Release(d_gstate);


### PR DESCRIPTION
When testing this on a RPI this causes issues, so we need to switch
based on the architecture.

I'm not a fan of the not compile time check with macros, but didn't see if you have a 64 bit macro elsewhere. Since a compiler should be smart enough to optimize away the branching I think it's fine? Lemme know if you'd prefer it done some other way