### PR TITLE
fix missing ARCHIVE DESTINATION for static building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ project(gattlib)
 option(GATTLIB_BUILD_EXAMPLES "Build GattLib examples" YES)
 option(GATTLIB_SHARED_LIB "Build GattLib as a shared library" YES)
 option(GATTLIB_BUILD_DOCS "Build GattLib docs" YES)
+option(GATTLIB_PYTHON_INTERFACE "Build GattLib Python Interface" YES)
 
 find_package(PkgConfig REQUIRED)
 find_package(Doxygen)

--- a/dbus/CMakeLists.txt
+++ b/dbus/CMakeLists.txt
@@ -104,12 +104,14 @@ set(gattlib_LIBS ${GLIB_LDFLAGS} ${GIO_UNIX_LDFLAGS})
 #
 # Add Python Support
 #
-find_package(Python COMPONENTS Interpreter Development)
-if (Python_Development_FOUND)
+if(GATTLIB_PYTHON_INTERFACE)
+  find_package(Python COMPONENTS Interpreter Development)
+  if (Python_Development_FOUND)
 	include_directories(${Python_INCLUDE_DIRS})
 	list(APPEND gattlib_LIBS ${Python_LIBRARIES})
 
 	add_definitions(-DWITH_PYTHON)
+  endif()
 endif()
 
 # Gattlib

--- a/dbus/CMakeLists.txt
+++ b/dbus/CMakeLists.txt
@@ -124,4 +124,8 @@ target_link_libraries(gattlib ${gattlib_LIBS})
 
 include(GNUInstallDirs)
 
-install(TARGETS gattlib LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+if(GATTLIB_SHARED_LIB)
+  install(TARGETS gattlib LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+else()
+  install(TARGETS gattlib ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif()


### PR DESCRIPTION
solves this issue..
```
cmake -DGATTLIB_SHARED_LIB=NO ..
CMake Error at dbus/CMakeLists.txt:127 (install):
  install TARGETS given no ARCHIVE DESTINATION for static library target
  "gattlib".
```

cmake version is 3.10.2