### PR TITLE
Allow gattlib to be added as a cmake subdirectory (add_subdirectory)

### DIFF
--- a/dbus/CMakeLists.txt
+++ b/dbus/CMakeLists.txt
@@ -78,7 +78,7 @@ add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/org-bluez-battery1.c
                    COMMENT "Generate D-Bus 'org.bluez.Battery1.xml'"
                    )
 
-include_directories(. ${CMAKE_SOURCE_DIR}/common ${CMAKE_CURRENT_BINARY_DIR} ${GIO_UNIX_INCLUDE_DIRS} ${BLUEZ_INCLUDE_DIRS})
+include_directories(. ${CMAKE_CURRENT_LIST_DIR}/../common ${CMAKE_CURRENT_BINARY_DIR} ${GIO_UNIX_INCLUDE_DIRS} ${BLUEZ_INCLUDE_DIRS})
 
 set(gattlib_SRCS gattlib.c
                  gattlib_adapter.c
@@ -87,8 +87,8 @@ set(gattlib_SRCS gattlib.c
                  gattlib_notification.c
                  gattlib_stream.c
                  bluez5/lib/uuid.c
-                 ${CMAKE_SOURCE_DIR}/common/gattlib_common.c
-                 ${CMAKE_SOURCE_DIR}/common/gattlib_eddystone.c
+                 ${CMAKE_CURRENT_LIST_DIR}/../common/gattlib_common.c
+                 ${CMAKE_CURRENT_LIST_DIR}/../common/gattlib_eddystone.c
                  ${CMAKE_CURRENT_BINARY_DIR}/org-bluez-adaptater1.c
                  ${CMAKE_CURRENT_BINARY_DIR}/org-bluez-device1.c
                  ${CMAKE_CURRENT_BINARY_DIR}/org-bluez-gattcharacteristic1.c


### PR DESCRIPTION
Once added as a submodule the gattlib library can be linked as below

```
set(GATTLIB_BUILD_DOCS OFF CACHE BOOLEAN "")
set(GATTLIB_PYTHON_INTERFACE OFF CACHE BOOLEAN "")
add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/gattlib gattlib)
target_link_libraries(bluetooth.linux.client PUBLIC gattlib Threads::Threads)
target_compile_options(gattlib PRIVATE
        -Wno-enum-conversion
        -Wno-sometimes-uninitialized
)
```
