### PR TITLE
Fixed bug where notifications will be enabled but no events will be received.

### DIFF
--- a/dbus/gattlib_internal.h
+++ b/dbus/gattlib_internal.h
@@ -25,6 +25,7 @@
 #define __GATTLIB_INTERNAL_H__
 
 #include <assert.h>
+#include <pthread.h>
 
 #include "gattlib_internal_defs.h"
 #include "gattlib.h"
@@ -52,8 +53,8 @@ typedef struct {
 	char* device_object_path;
 	OrgBluezDevice1* device;
 
-	// This attribute is only used during the connection stage. By placing the attribute here, we can pass
-	// `gatt_connection_t` to
+	// These attributes are needed to handle incoming events from GLib
+	pthread_t event_thread;
 	GMainLoop *connection_loop;
 	// ID of the timeout to know if we managed to connect to the device
 	guint connection_timeout;


### PR DESCRIPTION
For `g_signal_connect` to work, the process (either outside or within the library) needs to have at least one `GMainLoop` active to handle all the incoming events.

When a connection is established, create a pthread that keeps a main event loop open, and close it when disconnect is called.

Fixes:
- https://github.com/labapart/gattlib/issues/203
- https://github.com/labapart/gattlib/issues/199
- https://github.com/labapart/gattlib/issues/192
