### PR TITLE
Add verification for null mac address.

### DIFF
--- a/dbus/gattlib.c
+++ b/dbus/gattlib.c
@@ -848,7 +848,7 @@ int gattlib_get_rssi_from_mac(void *adapter, const char *mac_address, int16_t *r
 	OrgBluezDevice1 *bluez_device1;
 	int ret;
 
-	if (rssi == NULL) {
+	if (rssi == NULL || mac_address == NULL) {
 		return GATTLIB_INVALID_PARAMETER;
 	}
 


### PR DESCRIPTION
Sometimes, the callback for `gattlib_adapter_scan_enable` will receive a NULL mac_address, which can then by fed into `gattlib_get_rssi_from_mac` by accident, causing a segfault.