### PR TITLE
fix memory leak errors

### DIFF
--- a/dbus/gattlib_adapter.c
+++ b/dbus/gattlib_adapter.c
@@ -351,8 +351,13 @@ int gattlib_adapter_close(void* adapter)
 {
 	struct gattlib_adapter *gattlib_adapter = adapter;
 
-	g_object_unref(gattlib_adapter->device_manager);
+	if (gattlib_adapter->device_manager != NULL)
+		g_object_unref(gattlib_adapter->device_manager);
+	
 	g_object_unref(gattlib_adapter->adapter_proxy);
+
+	if (gattlib_adapter->adapter_name != NULL)
+		free(gattlib_adapter->adapter_name);
 	free(gattlib_adapter);
 
 	return GATTLIB_SUCCESS;

--- a/dbus/gattlib_internal.h
+++ b/dbus/gattlib_internal.h
@@ -64,6 +64,8 @@ typedef struct {
 
 	// List of 'OrgBluezGattCharacteristic1*' which has an attached notification
 	GList *notified_characteristics;
+
+	int need_release_adapter;
 } gattlib_context_t;
 
 struct gattlib_adapter {

--- a/dbus/gattlib_notification.c
+++ b/dbus/gattlib_notification.c
@@ -102,7 +102,6 @@ static gboolean on_handle_characteristic_property_change(
 							&uuid, data, data_length);
 
 					// As per https://developer.gnome.org/glib/stable/glib-GVariant.html#g-variant-iter-loop, clean up `key` and `value`.
-					//&sv, key is fixed memory
 					g_variant_unref(value);
 					break;
 				}

--- a/dbus/gattlib_notification.c
+++ b/dbus/gattlib_notification.c
@@ -104,8 +104,6 @@ static gboolean on_handle_characteristic_property_change(
 				}
 			}
 
-			if (key != NULL)
-				g_free(key);
 			if (value != NULL)
 				g_variant_unref(value);
 				

--- a/dbus/gattlib_notification.c
+++ b/dbus/gattlib_notification.c
@@ -102,7 +102,7 @@ static gboolean on_handle_characteristic_property_change(
 							&uuid, data, data_length);
 
 					// As per https://developer.gnome.org/glib/stable/glib-GVariant.html#g-variant-iter-loop, clean up `key` and `value`.
-					g_free(key);
+					//&sv, key is fixed memory
 					g_variant_unref(value);
 					break;
 				}
@@ -270,6 +270,6 @@ void disconnect_all_notifications(gattlib_context_t* conn_context) {
 		g_signal_handler_disconnect(notification_handle->gatt, notification_handle->signal_id);
 		free(notification_handle);
 	}
-
-	g_list_free_full(conn_context->notified_characteristics, g_object_unref);
+	
+	g_list_free(conn_context->notified_characteristics);
 }

--- a/dbus/gattlib_notification.c
+++ b/dbus/gattlib_notification.c
@@ -102,6 +102,10 @@ static gboolean on_handle_characteristic_property_change(
 							&uuid, data, data_length);
 
 					// As per https://developer.gnome.org/glib/stable/glib-GVariant.html#g-variant-iter-loop, clean up `key` and `value`.
+
+					// cause error "free(): invalid next size (fast)", https://developer.gnome.org/glib/stable/gvariant-format-strings.html, see "Characters: &" 
+					// ...This pointer should not be freed.
+					// g_free(key) 
 					g_variant_unref(value);
 					break;
 				}


### PR DESCRIPTION
"{&sv}" format string in loop, no need free the key. see "https://developer.gnome.org/glib/stable/gvariant-format-strings.html" section "Characters: &".