### PR TITLE
fix glib CRITICAL warning

### DIFF
--- a/bluez/gattlib_connect.c
+++ b/bluez/gattlib_connect.c
@@ -417,8 +417,9 @@ static gatt_connection_t *gattlib_connect_with_options(const char *src, const ch
 	while ((io_connect_arg.connected == FALSE) && (io_connect_arg.timeout == FALSE)) {
 		g_main_context_iteration(g_gattlib_thread.loop_context, FALSE);
 	}
-	// Disconnect the timeout source
-	g_source_destroy(timeout);
+	
+	// Disconnect the timeout source if connection success
+	if (io_connect_arg.connected) g_source_destroy(timeout);
 
 	if (io_connect_arg.timeout) {
 		return NULL;


### PR DESCRIPTION
	In the case when we deal with the timeout/error result, the resource
has already been unref and a glib CRITICAL waring pop.

Signed-off-by: vlefebvre <valentin.lefebvre@iot.bzh>