### PR TITLE
fix hard path during installation of gattlib

### DIFF
--- a/bluez/CMakeLists.txt
+++ b/bluez/CMakeLists.txt
@@ -99,13 +99,16 @@ else()
 endif()
 
 # gattlib
+include(GNUInstallDirs)
 if(GATTLIB_SHARED_LIB)
   add_library(gattlib SHARED ${gattlib_SRCS})
   target_link_libraries(gattlib ${gattlib_LIBS})
   
-  install(TARGETS gattlib LIBRARY DESTINATION lib)
+  install(TARGETS gattlib LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 else()
   add_library(gattlib ${gattlib_SRCS})
   target_include_directories(gattlib INTERFACE ../include)
   target_link_libraries(gattlib ${gattlib_LIBS})
+  
+  install(TARGETS gattlib LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()


### PR DESCRIPTION
	Using CMAKE macro to install correctly the library gattlib. In
aarch64 it will install into /usr/lib64 dir insteed of /usr/lib.

Signed-off-by: vlefebvre <valentin.lefebvre@iot.bzh>