### PR TITLE
Flush uart after getting message

### DIFF
--- a/examples/nordic_uart/nordic_uart.c
+++ b/examples/nordic_uart/nordic_uart.c
@@ -44,6 +44,7 @@ void notification_cb(const uuid_t* uuid, const uint8_t* data, size_t data_length
 	for(i = 0; i < data_length; i++) {
 		printf("%c", data[i]);
 	}
+    fflush(stdout);
 }
 
 static void usage(char *argv[]) {


### PR DESCRIPTION
The internal stdout buffering causes problems when we're trying to get
data, but the data doesn't have any newlines or anything like that.
We're forced to wait for forever until the buffer gets filled up and
output to the console.

This solves that by flushing immediately after each message.