### PR TITLE
fix: gattlib_adapter not found => SIGSEV

### DIFF
--- a/dbus/gattlib.c
+++ b/dbus/gattlib.c
@@ -131,6 +131,11 @@ gatt_connection_t *gattlib_connect(void* adapter, const char *dst, unsigned long
 		adapter_name = gattlib_adapter->adapter_name;
 	}
 
+    // even after init_default_adapter() - the adapter can be NULL
+    if (gattlib_adapter == NULL) {
+        return NULL;
+    }
+
 	get_device_path_from_mac(adapter_name, dst, object_path, sizeof(object_path));
 
 	gattlib_context_t* conn_context = calloc(sizeof(gattlib_context_t), 1);

--- a/dbus/gattlib.c
+++ b/dbus/gattlib.c
@@ -205,6 +205,9 @@ gatt_connection_t *gattlib_connect(void* adapter, const char *dst, unsigned long
 
 	// Get list of objects belonging to Device Manager
 	device_manager = get_device_manager_from_adapter(conn_context->adapter);
+    if (device_manager == NULL) {
+        goto FREE_DEVICE;
+    }
 	conn_context->dbus_objects = g_dbus_object_manager_get_objects(device_manager);
 
 	// Set up a new GMainLoop to handle notification/indication events.


### PR DESCRIPTION
I had the issue that the default adapter went to power save mode and sometimes wasnt availabe and yielded into a SIGSEV in gattlib.

The fix properly returns NULL if the adapter is not available.