### PR TITLE
add nullptr checks

### DIFF
--- a/dbus/gattlib.c
+++ b/dbus/gattlib.c
@@ -131,6 +131,11 @@ gatt_connection_t *gattlib_connect(void* adapter, const char *dst, unsigned long
 		adapter_name = gattlib_adapter->adapter_name;
 	}
 
+    // even after init_default_adapter() - the adapter can be NULL
+    if (gattlib_adapter == NULL) {
+        return NULL;
+    }
+
 	get_device_path_from_mac(adapter_name, dst, object_path, sizeof(object_path));
 
 	gattlib_context_t* conn_context = calloc(sizeof(gattlib_context_t), 1);

--- a/dbus/gattlib.c
+++ b/dbus/gattlib.c
@@ -408,7 +408,17 @@ int gattlib_discover_primary(gatt_connection_t* connection, gattlib_primary_serv
 		}
 
 		// Ensure the service is attached to this device
-		if (strcmp(conn_context->device_object_path, org_bluez_gatt_service1_get_device(service_proxy))) {
+        const gchar * service_property = org_bluez_gatt_service1_get_device(service_proxy);
+        if (service_property == NULL) {
+            if (error) {
+                GATTLIB_LOG(GATTLIB_ERROR, "Failed to get service property '%s': %s", object_path, error->message);
+                g_error_free(error);
+            } else {
+                GATTLIB_LOG(GATTLIB_ERROR, "Failed to get service property '%s'.", object_path);
+            }
+            continue;
+        }
+		if (strcmp(conn_context->device_object_path, service_property)) {
 			g_object_unref(service_proxy);
 			continue;
 		}

--- a/dbus/gattlib.c
+++ b/dbus/gattlib.c
@@ -205,6 +205,9 @@ gatt_connection_t *gattlib_connect(void* adapter, const char *dst, unsigned long
 
 	// Get list of objects belonging to Device Manager
 	device_manager = get_device_manager_from_adapter(conn_context->adapter);
+    if (device_manager == NULL) {
+        goto FREE_DEVICE;
+    }
 	conn_context->dbus_objects = g_dbus_object_manager_get_objects(device_manager);
 
 	// Set up a new GMainLoop to handle notification/indication events.

--- a/dbus/gattlib.c
+++ b/dbus/gattlib.c
@@ -669,7 +669,17 @@ static void add_characteristics_from_service(gattlib_context_t* conn_context, GD
 			continue;
 		}
 
-		if (strcmp(org_bluez_gatt_characteristic1_get_service(characteristic), service_object_path)) {
+        const gchar * property_value = org_bluez_gatt_characteristic1_get_service(characteristic);
+        if (property_value == NULL){
+            if (error) {
+                GATTLIB_LOG(GATTLIB_ERROR, "Failed to get service '%s': %s", object_path, error->message);
+                g_error_free(error);
+            } else {
+                GATTLIB_LOG(GATTLIB_ERROR, "Failed to get service '%s'.", object_path);
+            }
+            continue;
+        }
+		if (strcmp(property_value, service_object_path)) {
 			g_object_unref(characteristic);
 			continue;
 		} else {


### PR DESCRIPTION
when running the libarary I did notice some issues. no big changes, just some checks for nullptr and quick cleanup and return.