### PR TITLE
Add missing include

### DIFF
--- a/common/gattlib_common_adapter.c
+++ b/common/gattlib_common_adapter.c
@@ -4,6 +4,8 @@
  * Copyright (c) 2021-2024, Olivier Martin <olivier@labapart.org>
  */
 
+#include <ctype.h>
+
 #include "gattlib_internal.h"
 
 // Keep track of the allocated adapters to avoid an adapter to be freed twice.


### PR DESCRIPTION
Add missing include to fix implicit declaration issue:

```
/builddir/build/BUILD/gattlib-0.7.1/common/gattlib_common_adapter.c: In function ‘stricmp’:
/builddir/build/BUILD/gattlib-0.7.1/common/gattlib_common_adapter.c:15:17: error: implicit declaration of function ‘tolower’ [-Wimplicit-function-declaration]
   15 |         int d = tolower((unsigned char)*a) - tolower((unsigned char)*b);
      |                 ^~~~~~~
/builddir/build/BUILD/gattlib-0.7.1/common/gattlib_common_adapter.c:8:1: note: include ‘<ctype.h>’ or provide a declaration of ‘tolower’
    7 | #include "gattlib_internal.h"
  +++ |+#include <ctype.h>
    8 | 
gmake[2]: *** [dbus/CMakeFiles/gattlib.dir/build.make:215: dbus/CMakeFiles/gattlib.dir/__/common/gattlib_common_adapter.c.o] Error 1
```